### PR TITLE
voxel: multi-chunk world with spiral loading and RegionAnchor abstrac…

### DIFF
--- a/utils/swindowzig/build.zig
+++ b/utils/swindowzig/build.zig
@@ -98,9 +98,14 @@ pub fn build(b: *std.Build) void {
     native_exe.root_module.addImport("sw_gpu", sw_gpu);
     native_exe.root_module.addImport("sw_core", sw_core);
 
-    // Link SDL2 for native builds
+    // Link SDL2 for native builds.
+    // sw_platform's @cImport needs the SDL2 headers to be visible.
+    // In Zig 0.15.x the include paths added to the exe are not automatically
+    // propagated to separately-compiled modules, so we add them explicitly here.
     native_exe.linkSystemLibrary("SDL2");
     native_exe.linkLibC();
+    // Ensure SDL2 headers are available to the sw_platform module's @cImport.
+    sw_platform.addIncludePath(.{ .cwd_relative = "/opt/homebrew/include" });
 
     // Link wgpu-native from ~/.local
     const home = std.process.getEnvVarOwned(b.allocator, "HOME") catch unreachable;

--- a/utils/swindowzig/examples/voxel/chunk.zig
+++ b/utils/swindowzig/examples/voxel/chunk.zig
@@ -63,3 +63,14 @@ pub const Chunk = struct {
         }
     }
 };
+
+/// Type-erased block source. Allows player physics and raycasting to work with
+/// either a single Chunk (local coords) or a World (world coords).
+pub const BlockGetter = struct {
+    ctx: *const anyopaque,
+    getFn: *const fn (ctx: *const anyopaque, x: i32, y: i32, z: i32) BlockType,
+
+    pub fn getBlock(self: BlockGetter, x: i32, y: i32, z: i32) BlockType {
+        return self.getFn(self.ctx, x, y, z);
+    }
+};

--- a/utils/swindowzig/examples/voxel/main.zig
+++ b/utils/swindowzig/examples/voxel/main.zig
@@ -89,12 +89,17 @@ const mesher_mod = @import("mesher.zig");
 const Mesh = mesher_mod.Mesh;
 const VoxelVertex = mesher_mod.VoxelVertex;
 
+const world_mod = @import("world.zig");
+
 const Vec3 = math.Vec3;
 const Mat4 = math.Mat4;
 
 const CameraType = @import("camera.zig").Camera(Vec3, Mat4, math);
-const RaycastType = @import("raycast.zig").Raycast(Vec3, Chunk);
-const raycast = RaycastType.raycast;
+const WorldRaycastType = @import("raycast.zig").Raycast(Vec3, world_mod.World);
+const worldRaycast = WorldRaycastType.raycast;
+
+/// Max mesh generations per render frame (keeps frame time bounded during chunk loading).
+const MESH_GENS_PER_FRAME: usize = 1;
 
 const GameState = @import("game_state.zig").GameState;
 const OverlayRenderer = @import("overlay.zig").OverlayRenderer;
@@ -130,16 +135,19 @@ const RESUME_BTN_W: f32 = 200;
 const RESUME_BTN_H: f32 = 40;
 const BTN_GAP: f32 = 12; // gap between resume and quit buttons
 
+const ChunkGPU = struct {
+    vertex_buffer: ?gpu_mod.Buffer = null,
+    index_buffer: ?gpu_mod.Buffer = null,
+};
+
 // Application state
 const State = struct {
-    chunk: Chunk,
-    mesh: Mesh,
+    world: world_mod.World,
+    chunk_gpu: std.HashMap(world_mod.ChunkKey, ChunkGPU, world_mod.ChunkKey.HashContext, std.hash_map.default_max_load_percentage),
     camera: CameraType,
     player: Player,
     pipeline: ?gpu_mod.RenderPipeline = null,
     cylinder_pipeline: ?gpu_mod.RenderPipeline = null,
-    vertex_buffer: ?gpu_mod.Buffer = null,
-    index_buffer: ?gpu_mod.Buffer = null,
     uniform_buffer: ?gpu_mod.Buffer = null,
     bind_group: ?gpu_mod.BindGroup = null,
     depth_texture: ?gpu_mod.Texture = null,
@@ -152,8 +160,6 @@ const State = struct {
     border_index_buffer: ?gpu_mod.Buffer = null,
     border_vert_count: usize = 0,
     border_idx_count: usize = 0,
-    mesh_dirty: bool = true,
-    mesh_incremental_dirty: bool = false,
     mouse_captured: bool = false,
     click_locked: bool = false,
     paused_with_mouse: bool = false,
@@ -187,8 +193,6 @@ fn voxelInit(ctx: *sw.Context) !void {
     // Explicitly null all optional fields — `var state: State = undefined` bypasses struct defaults
     state.pipeline = null;
     state.cylinder_pipeline = null;
-    state.vertex_buffer = null;
-    state.index_buffer = null;
     state.uniform_buffer = null;
     state.bind_group = null;
     state.depth_texture = null;
@@ -202,12 +206,9 @@ fn voxelInit(ctx: *sw.Context) !void {
     state.hover_block = null;
     state.tas_replayer = null;
 
-    // Initialize chunk
-    state.chunk = Chunk.init();
-    state.chunk.generateTerrain();
-
-    // Initialize mesh
-    state.mesh = Mesh.init(ctx.allocator());
+    // Initialize world (replaces single chunk + mesh)
+    state.world = try world_mod.World.init(ctx.allocator());
+    state.chunk_gpu = std.HashMap(world_mod.ChunkKey, ChunkGPU, world_mod.ChunkKey.HashContext, std.hash_map.default_max_load_percentage).init(ctx.allocator());
 
     // Initialize camera
     const window_info = ctx.window();
@@ -233,8 +234,6 @@ fn voxelInit(ctx: *sw.Context) !void {
     state.tas_current_tas_tick = 0;
     state.gpu_debug = false;
 
-    state.mesh_dirty = true;
-    state.mesh_incremental_dirty = false;
     state.mouse_captured = false;
     state.click_locked = false;
     state.paused_with_mouse = false;
@@ -306,6 +305,12 @@ fn voxelInit(ctx: *sw.Context) !void {
 }
 
 fn voxelTick(ctx: *sw.Context) !void {
+    // Update world: load chunks progressively around active region anchors.
+    // The player is currently the only anchor.
+    try state.world.update(&[_]world_mod.RegionAnchor{
+        .{ .position = state.player.feet_pos },
+    });
+
     // TAS playback status + headless auto-shutdown when script completes
     if (state.tas_replayer) |*replayer| {
         if (ctx.tickId() % 60 == 0) {
@@ -463,7 +468,7 @@ fn voxelTick(ctx: *sw.Context) !void {
             const space_held = input.keyDown(.Space);
             const sprint = input.keyDown(.Shift);
 
-            state.player.tick(&state.chunk, dt, state.camera.yaw, fwd, rgt, jump, space_held, sprint);
+            state.player.tick(state.world.asBlockGetter(), dt, state.camera.yaw, fwd, rgt, jump, space_held, sprint);
 
             // Sync camera position to player eye, offset by camera view.
             const eye = state.player.eyePos();
@@ -508,7 +513,7 @@ fn voxelTick(ctx: *sw.Context) !void {
             const cam_dir = state.camera.forward();
             const eye_pos = state.player.eyePos();
             const ray_origin = Vec3.init(eye_pos[0], eye_pos[1], eye_pos[2]);
-            const hit = raycast(&state.chunk, ray_origin, cam_dir, 5.0);
+            const hit = worldRaycast(&state.world, ray_origin, cam_dir, 5.0);
 
             if (hit.hit) {
                 state.hover_block = hit.block_pos;
@@ -519,15 +524,26 @@ fn voxelTick(ctx: *sw.Context) !void {
                     const bx: i32 = @intFromFloat(hit.block_pos.x);
                     const by: i32 = @intFromFloat(hit.block_pos.y);
                     const bz: i32 = @intFromFloat(hit.block_pos.z);
-                    state.chunk.setBlock(bx, by, bz, .air);
-                    const t_incr0 = std.time.nanoTimestamp();
-                    state.mesh.updateForBlockChange(&state.chunk, bx, by, bz, .{ state.camera.position.x, state.camera.position.y, state.camera.position.z }) catch |err| {
-                        std.log.err("Incremental mesh update failed: {} — falling back to full regen", .{err});
-                        state.mesh_dirty = true;
-                    };
-                    const t_incr_us = @divTrunc(std.time.nanoTimestamp() - t_incr0, 1000);
-                    std.log.info("[TICK  tick={d:4}] incremental remove ({},{},{}) update={}us", .{ ctx.tickId(), bx, by, bz, t_incr_us });
-                    state.mesh_incremental_dirty = true;
+                    _ = state.world.setBlock(bx, by, bz, .air);
+                    if (state.world.getChunkAtBlock(bx, bz)) |lc| {
+                        const lcx = world_mod.chunkCoordOf(bx);
+                        const lcz = world_mod.chunkCoordOf(bz);
+                        const lbx = bx - lcx * chunk_mod.CHUNK_W;
+                        const lbz = bz - lcz * chunk_mod.CHUNK_W;
+                        const t_incr0 = std.time.nanoTimestamp();
+                        lc.mesh.updateForBlockChange(
+                            &lc.chunk, lbx, by, lbz,
+                            .{ state.camera.position.x, state.camera.position.y, state.camera.position.z },
+                            lc.worldX(), lc.worldZ(),
+                            state.world.asBlockGetter(),
+                        ) catch |err| {
+                            std.log.err("Incremental mesh update failed: {} — falling back to full regen", .{err});
+                            lc.mesh_dirty = true;
+                        };
+                        const t_incr_us = @divTrunc(std.time.nanoTimestamp() - t_incr0, 1000);
+                        std.log.info("[TICK  tick={d:4}] incremental remove ({},{},{}) update={}us", .{ ctx.tickId(), bx, by, bz, t_incr_us });
+                        lc.mesh_incremental_dirty = true;
+                    }
                 }
 
                 // Right click: place block on adjacent face
@@ -540,15 +556,26 @@ fn voxelTick(ctx: *sw.Context) !void {
                     const px: i32 = @intFromFloat(place_pos.x);
                     const py: i32 = @intFromFloat(place_pos.y);
                     const pz: i32 = @intFromFloat(place_pos.z);
-                    state.chunk.setBlock(px, py, pz, .stone);
-                    const t_incr0 = std.time.nanoTimestamp();
-                    state.mesh.updateForBlockChange(&state.chunk, px, py, pz, .{ state.camera.position.x, state.camera.position.y, state.camera.position.z }) catch |err| {
-                        std.log.err("Incremental mesh update failed: {} — falling back to full regen", .{err});
-                        state.mesh_dirty = true;
-                    };
-                    const t_incr_us = @divTrunc(std.time.nanoTimestamp() - t_incr0, 1000);
-                    std.log.info("[TICK  tick={d:4}] incremental place ({},{},{}) update={}us", .{ ctx.tickId(), px, py, pz, t_incr_us });
-                    state.mesh_incremental_dirty = true;
+                    _ = state.world.setBlock(px, py, pz, .stone);
+                    if (state.world.getChunkAtBlock(px, pz)) |lc| {
+                        const lcx = world_mod.chunkCoordOf(px);
+                        const lcz = world_mod.chunkCoordOf(pz);
+                        const lpx = px - lcx * chunk_mod.CHUNK_W;
+                        const lpz = pz - lcz * chunk_mod.CHUNK_W;
+                        const t_incr0 = std.time.nanoTimestamp();
+                        lc.mesh.updateForBlockChange(
+                            &lc.chunk, lpx, py, lpz,
+                            .{ state.camera.position.x, state.camera.position.y, state.camera.position.z },
+                            lc.worldX(), lc.worldZ(),
+                            state.world.asBlockGetter(),
+                        ) catch |err| {
+                            std.log.err("Incremental mesh update failed: {} — falling back to full regen", .{err});
+                            lc.mesh_dirty = true;
+                        };
+                        const t_incr_us = @divTrunc(std.time.nanoTimestamp() - t_incr0, 1000);
+                        std.log.info("[TICK  tick={d:4}] incremental place ({},{},{}) update={}us", .{ ctx.tickId(), px, py, pz, t_incr_us });
+                        lc.mesh_incremental_dirty = true;
+                    }
                 }
             } else {
                 if (!state.tas_step_mode or state.tas_step_executing) state.hover_block = null;
@@ -565,7 +592,10 @@ fn voxelTick(ctx: *sw.Context) !void {
     // GPU debug: decay highlight intensity each tick so rebuilt faces fade out over ~0.5s.
     // In TAS step mode, only decay on executing ticks (preserves highlights between steps).
     if (state.gpu_debug and (!state.tas_step_mode or state.tas_step_executing)) {
-        state.mesh.decayHighlights(4);
+        var it = state.world.chunks.valueIterator();
+        while (it.next()) |lc_ptr| {
+            lc_ptr.*.mesh.decayHighlights(4);
+        }
     }
 }
 
@@ -682,7 +712,8 @@ fn drawStepHud(
 
 /// Build chunk border wireframe: 12 edges of the bounding box, each as two
 /// perpendicular thin quads (cross shape) so they're visible from any angle.
-fn buildChunkBorderMesh(g: *gpu_mod.GPU) void {
+/// ox/oz are the world-space X/Z origin of the chunk to draw the border for.
+fn buildChunkBorderMesh(g: *gpu_mod.GPU, ox: f32, oz: f32) void {
     const W: f32 = @floatFromInt(chunk_mod.CHUNK_W);
     const H: f32 = @floatFromInt(chunk_mod.CHUNK_H);
     const t: f32 = 0.02; // half-thickness of each line
@@ -716,8 +747,8 @@ fn buildChunkBorderMesh(g: *gpu_mod.GPU) void {
     // Vertical edges (4 corners, each a cross of XZ-perpendicular quads)
     const corners = [_][2]f32{ .{ 0, 0 }, .{ W, 0 }, .{ 0, W }, .{ W, W } };
     for (corners) |c| {
-        const cx = c[0];
-        const cz = c[1];
+        const cx = ox + c[0];
+        const cz = oz + c[1];
         // Quad facing ±Z
         addQ(&verts, &idxs, &vi, &ii, .{ cx - t, 0, cz }, .{ cx - t, H, cz }, .{ cx + t, H, cz }, .{ cx + t, 0, cz }, bt, n_zero);
         // Quad facing ±X
@@ -726,31 +757,31 @@ fn buildChunkBorderMesh(g: *gpu_mod.GPU) void {
 
     // Horizontal edges along X (4: bottom + top, at Z=0 and Z=W)
     const y_levels = [_]f32{ 0, H };
-    const z_edges = [_]f32{ 0, W };
+    const z_edges = [_]f32{ oz, oz + W };
     for (y_levels) |y| {
         for (z_edges) |z| {
             // Quad facing ±Y
-            addQ(&verts, &idxs, &vi, &ii, .{ 0, y, z - t }, .{ W, y, z - t }, .{ W, y, z + t }, .{ 0, y, z + t }, bt, n_zero);
+            addQ(&verts, &idxs, &vi, &ii, .{ ox, y, z - t }, .{ ox + W, y, z - t }, .{ ox + W, y, z + t }, .{ ox, y, z + t }, bt, n_zero);
             // Quad facing ±Z
-            addQ(&verts, &idxs, &vi, &ii, .{ 0, y - t, z }, .{ W, y - t, z }, .{ W, y + t, z }, .{ 0, y + t, z }, bt, n_zero);
+            addQ(&verts, &idxs, &vi, &ii, .{ ox, y - t, z }, .{ ox + W, y - t, z }, .{ ox + W, y + t, z }, .{ ox, y + t, z }, bt, n_zero);
         }
     }
 
     // Horizontal edges along Z (4: bottom + top, at X=0 and X=W)
-    const x_edges = [_]f32{ 0, W };
+    const x_edges = [_]f32{ ox, ox + W };
     for (y_levels) |y| {
         for (x_edges) |x| {
             // Quad facing ±Y
-            addQ(&verts, &idxs, &vi, &ii, .{ x - t, y, 0 }, .{ x + t, y, 0 }, .{ x + t, y, W }, .{ x - t, y, W }, bt, n_zero);
+            addQ(&verts, &idxs, &vi, &ii, .{ x - t, y, oz }, .{ x + t, y, oz }, .{ x + t, y, oz + W }, .{ x - t, y, oz + W }, bt, n_zero);
             // Quad facing ±X
-            addQ(&verts, &idxs, &vi, &ii, .{ x, y - t, 0 }, .{ x, y + t, 0 }, .{ x, y + t, W }, .{ x, y - t, W }, bt, n_zero);
+            addQ(&verts, &idxs, &vi, &ii, .{ x, y - t, oz }, .{ x, y + t, oz }, .{ x, y + t, oz + W }, .{ x, y - t, oz + W }, bt, n_zero);
         }
     }
 
     state.border_vert_count = vi;
     state.border_idx_count = ii;
 
-    // Create or reuse GPU buffers (static — only built once)
+    // Create GPU buffers if needed; always re-upload since ox/oz can change frame to frame.
     if (state.border_vertex_buffer == null) {
         state.border_vertex_buffer = g.createBuffer(.{
             .size = verts.len * @sizeOf(VoxelVertex),
@@ -793,51 +824,59 @@ fn voxelRender(ctx: *sw.Context) !void {
         };
     }
 
-    // Regenerate mesh if chunk changed
-    const was_dirty = state.mesh_dirty;
-    var t_mesh_us: i128 = 0;
-    if (state.mesh_dirty) {
-        const t0 = std.time.nanoTimestamp();
-        mesher_mod.generateMesh(&state.chunk, &state.mesh) catch |err| {
-            std.log.err("Failed to generate mesh: {}", .{err});
-            return;
-        };
-        t_mesh_us = @divTrunc(std.time.nanoTimestamp() - t0, 1000);
-        state.mesh_dirty = false;
+    // Regenerate dirty meshes — limit to MESH_GENS_PER_FRAME to keep frame time bounded.
+    var mesh_gens_this_frame: usize = 0;
+    {
+        var it = state.world.chunks.iterator();
+        while (it.next()) |entry| {
+            if (mesh_gens_this_frame >= MESH_GENS_PER_FRAME) break;
+            const lc = entry.value_ptr.*;
+            if (!lc.mesh_dirty) continue;
+            const t0 = std.time.nanoTimestamp();
+            mesher_mod.generateMesh(
+                &lc.chunk,
+                &lc.mesh,
+                lc.worldX(),
+                lc.worldZ(),
+                state.world.asBlockGetter(),
+            ) catch |err| {
+                std.log.err("Mesh gen failed for chunk ({},{}): {}", .{ lc.cx, lc.cz, err });
+                continue;
+            };
+            const t_us = @divTrunc(std.time.nanoTimestamp() - t0, 1000);
+            std.log.info("[MESH] chunk ({},{}) gen={}us quads={}", .{ lc.cx, lc.cz, t_us, lc.mesh.indices.items.len / 6 });
+            lc.mesh_dirty = false;
+            lc.mesh_incremental_dirty = true;
+            mesh_gens_this_frame += 1;
+        }
     }
 
-    // Sort mesh by depth every frame (painter's algorithm for correct rendering without depth testing)
-    var t_sort_us: i128 = 0;
-    var t_upload_us: i128 = 0;
-    if (state.mesh.vertices.items.len > 0) {
-        const t1 = std.time.nanoTimestamp();
-        state.mesh.sortByDepth(.{
-            state.camera.position.x,
-            state.camera.position.y,
-            state.camera.position.z,
-        }) catch |err| {
-            std.log.err("Failed to sort mesh: {}", .{err});
-            return;
-        };
-        t_sort_us = @divTrunc(std.time.nanoTimestamp() - t1, 1000);
+    // Sort and upload each chunk's mesh.
+    {
+        var it = state.world.chunks.iterator();
+        while (it.next()) |entry| {
+            const key = entry.key_ptr.*;
+            const lc = entry.value_ptr.*;
+            if (lc.mesh.vertices.items.len == 0) continue;
 
-        const t2 = std.time.nanoTimestamp();
-        uploadMeshToGPU(g, was_dirty) catch |err| {
-            std.log.err("Failed to upload mesh: {}", .{err});
-            return;
-        };
-        t_upload_us = @divTrunc(std.time.nanoTimestamp() - t2, 1000);
+            lc.mesh.sortByDepth(.{
+                state.camera.position.x,
+                state.camera.position.y,
+                state.camera.position.z,
+            }) catch |err| {
+                std.log.err("Sort failed for chunk ({},{}): {}", .{ lc.cx, lc.cz, err });
+                continue;
+            };
+
+            const gop = state.chunk_gpu.getOrPut(key) catch continue;
+            if (!gop.found_existing) gop.value_ptr.* = .{};
+            uploadChunkMeshToGPU(g, lc, gop.value_ptr, lc.mesh_incremental_dirty) catch |err| {
+                std.log.err("Upload failed for chunk ({},{}): {}", .{ lc.cx, lc.cz, err });
+                continue;
+            };
+            if (lc.mesh_incremental_dirty) lc.mesh_incremental_dirty = false;
+        }
     }
-
-    // Per-frame timing log — always emit so we can compare normal vs spike frame
-    std.log.info("[RENDER tick={d:4}] dirty={} mesh={d:5}us sort={d:5}us upload={d:5}us  total={d:5}us", .{
-        ctx.tickId(),
-        was_dirty,
-        t_mesh_us,
-        t_sort_us,
-        t_upload_us,
-        t_mesh_us + t_sort_us + t_upload_us,
-    });
 
     // Update uniforms — front-facing view needs a flipped lookAt direction.
     const view_proj = if (state.camera_view == .third_person_front) blk: {
@@ -895,18 +934,38 @@ fn voxelRender(ctx: *sw.Context) !void {
         return;
     };
 
+    // Draw chunks back-to-front (painter's algorithm at chunk level).
+    // Build a temporary sorted list of chunks by distance from camera.
+    var sorted_chunks = std.ArrayList(*world_mod.LoadedChunk){};
+    defer sorted_chunks.deinit(ctx.allocator());
+    {
+        var it = state.world.chunks.valueIterator();
+        while (it.next()) |lc_ptr| {
+            if (lc_ptr.*.mesh.vertices.items.len == 0) continue;
+            sorted_chunks.append(ctx.allocator(), lc_ptr.*) catch continue;
+        }
+    }
+    const cam_pos = [3]f32{ state.camera.position.x, state.camera.position.y, state.camera.position.z };
+    std.mem.sort(*world_mod.LoadedChunk, sorted_chunks.items, cam_pos, struct {
+        fn lt(cam: [3]f32, a: *world_mod.LoadedChunk, b: *world_mod.LoadedChunk) bool {
+            const half: f32 = @as(f32, @floatFromInt(chunk_mod.CHUNK_W)) * 0.5;
+            const ax = a.worldXf() + half - cam[0];
+            const az = a.worldZf() + half - cam[2];
+            const bx = b.worldXf() + half - cam[0];
+            const bz = b.worldZf() + half - cam[2];
+            return (ax * ax + az * az) > (bx * bx + bz * bz); // far-first
+        }
+    }.lt);
+
     pass.setPipeline(state.pipeline.?);
     pass.setBindGroup(0, state.bind_group.?);
-
-    if (state.mesh.vertices.items.len > 0) {
-        const vertex_count = state.mesh.vertices.items.len;
-        const index_count = state.mesh.indices.items.len;
-
-        pass.setVertexBuffer(0, state.vertex_buffer.?, 0, vertex_count * @sizeOf(VoxelVertex));
-        pass.setIndexBuffer(state.index_buffer.?, .uint32, 0, index_count * @sizeOf(u32));
-
-        const index_count_u32: u32 = @intCast(index_count);
-        pass.drawIndexed(index_count_u32, 1, 0, 0, 0);
+    for (sorted_chunks.items) |lc| {
+        const key = world_mod.ChunkKey{ .cx = lc.cx, .cz = lc.cz };
+        const cg = state.chunk_gpu.get(key) orelse continue;
+        if (cg.vertex_buffer == null or cg.index_buffer == null) continue;
+        pass.setVertexBuffer(0, cg.vertex_buffer.?, 0, lc.mesh.vertices.items.len * @sizeOf(VoxelVertex));
+        pass.setIndexBuffer(cg.index_buffer.?, .uint32, 0, lc.mesh.indices.items.len * @sizeOf(u32));
+        pass.drawIndexed(@intCast(lc.mesh.indices.items.len), 1, 0, 0, 0);
     }
 
     // =========================================================================
@@ -938,7 +997,12 @@ fn voxelRender(ctx: *sw.Context) !void {
     // Chunk border wireframe (debug mode only; uses cylinder pipeline for alpha + no culling)
     // =========================================================================
     if (state.debug_mode and state.cylinder_pipeline != null) {
-        buildChunkBorderMesh(g);
+        // Draw border for the chunk the player is currently in.
+        const pcx = world_mod.chunkCoordOf(@as(i32, @intFromFloat(@floor(state.player.feet_pos[0]))));
+        const pcz = world_mod.chunkCoordOf(@as(i32, @intFromFloat(@floor(state.player.feet_pos[2]))));
+        const border_ox: f32 = @as(f32, @floatFromInt(pcx)) * @as(f32, @floatFromInt(chunk_mod.CHUNK_W));
+        const border_oz: f32 = @as(f32, @floatFromInt(pcz)) * @as(f32, @floatFromInt(chunk_mod.CHUNK_W));
+        buildChunkBorderMesh(g, border_ox, border_oz);
         if (state.border_vertex_buffer != null and state.border_idx_count > 0) {
             pass.setPipeline(state.cylinder_pipeline.?);
             pass.setBindGroup(0, state.bind_group.?);
@@ -962,7 +1026,7 @@ fn voxelRender(ctx: *sw.Context) !void {
         const cam_bx: i32 = @intFromFloat(@floor(state.camera.position.x));
         const cam_by: i32 = @intFromFloat(@floor(state.camera.position.y));
         const cam_bz: i32 = @intFromFloat(@floor(state.camera.position.z));
-        if (state.chunk.getBlock(cam_bx, cam_by, cam_bz) != .air) {
+        if (state.world.getBlock(cam_bx, cam_by, cam_bz) != .air) {
             // Dark purple base
             state.overlay.rect(0, 0, overlay_w, overlay_h, .{ 0.08, 0.02, 0.12, 1 }, overlay_w, overlay_h) catch {};
 
@@ -1076,7 +1140,15 @@ fn voxelRender(ctx: *sw.Context) !void {
 }
 
 fn voxelShutdown(ctx: *sw.Context) !void {
-    state.mesh.deinit();
+    // Destroy per-chunk GPU buffers
+    var it = state.chunk_gpu.iterator();
+    while (it.next()) |entry| {
+        if (entry.value_ptr.vertex_buffer) |buf| buf.destroy();
+        if (entry.value_ptr.index_buffer) |buf| buf.destroy();
+    }
+    state.chunk_gpu.deinit();
+    state.world.deinit();
+
     state.overlay.deinit();
     state.cylinder_verts.deinit(ctx.allocator());
     state.cylinder_indices.deinit(ctx.allocator());
@@ -1212,64 +1284,53 @@ fn setupGPUResources(g: *gpu_mod.GPU, width: u32, height: u32) !void {
     std.log.info("GPU resources created", .{});
 }
 
-fn uploadMeshToGPU(g: *gpu_mod.GPU, mesh_rebuilt: bool) !void {
-    const vertex_count = state.mesh.vertices.items.len;
-    const index_count = state.mesh.indices.items.len;
-    const sorted = state.mesh.sort_indices[0..index_count];
-    const structure_changed = mesh_rebuilt or state.mesh_incremental_dirty;
+fn uploadChunkMeshToGPU(g: *gpu_mod.GPU, lc: *world_mod.LoadedChunk, cg: *ChunkGPU, structure_changed: bool) !void {
+    const vertex_count = lc.mesh.vertices.items.len;
+    const index_count = lc.mesh.indices.items.len;
+    if (index_count == 0) return;
+    const sorted = lc.mesh.sort_indices[0..index_count];
 
-    if (structure_changed) {
-        // Vertex/index count changed — recreate GPU buffers.
-        if (state.vertex_buffer) |old_buf| old_buf.destroy();
-        state.vertex_buffer = try g.createBuffer(.{
+    if (structure_changed or cg.vertex_buffer == null) {
+        if (cg.vertex_buffer) |old| old.destroy();
+        cg.vertex_buffer = try g.createBuffer(.{
             .size = vertex_count * @sizeOf(VoxelVertex),
             .usage = .{ .vertex = true, .copy_dst = true },
         });
-
-        if (state.index_buffer) |old_buf| old_buf.destroy();
-        state.index_buffer = try g.createBuffer(.{
+        if (cg.index_buffer) |old| old.destroy();
+        cg.index_buffer = try g.createBuffer(.{
             .size = index_count * @sizeOf(u32),
             .usage = .{ .index = true, .copy_dst = true },
         });
-
-        state.mesh_incremental_dirty = false;
     }
 
-    // Write vertex data when structure changed, or every frame when gpu_debug
-    // (highlight values decay each tick, so block_type upper bits change).
     if (structure_changed or state.gpu_debug) {
         if (state.gpu_debug) {
-            // Temporarily encode highlight intensity into upper 8 bits of block_type.
             const quad_count = vertex_count / 4;
             for (0..quad_count) |qi| {
-                const hl = state.mesh.quad_highlight.items[qi];
+                const hl = lc.mesh.quad_highlight.items[qi];
                 if (hl > 0) {
                     const hl32 = @as(u32, hl) << 16;
                     const base = qi * 4;
                     for (base..base + 4) |vi| {
-                        state.mesh.vertices.items[vi].block_type |= hl32;
+                        lc.mesh.vertices.items[vi].block_type |= hl32;
                     }
                 }
             }
         }
-
-        g.writeBuffer(state.vertex_buffer.?, 0, std.mem.sliceAsBytes(state.mesh.vertices.items));
-
+        g.writeBuffer(cg.vertex_buffer.?, 0, std.mem.sliceAsBytes(lc.mesh.vertices.items));
         if (state.gpu_debug) {
-            // Restore block_type — remove highlight bits so mesh data stays clean.
             const quad_count = vertex_count / 4;
             for (0..quad_count) |qi| {
-                const hl = state.mesh.quad_highlight.items[qi];
+                const hl = lc.mesh.quad_highlight.items[qi];
                 if (hl > 0) {
                     const base = qi * 4;
                     for (base..base + 4) |vi| {
-                        state.mesh.vertices.items[vi].block_type &= 0xFFFF;
+                        lc.mesh.vertices.items[vi].block_type &= 0xFFFF;
                     }
                 }
             }
         }
     }
 
-    // Always write sorted indices — order changes every frame as camera moves.
-    g.writeBuffer(state.index_buffer.?, 0, std.mem.sliceAsBytes(sorted));
+    g.writeBuffer(cg.index_buffer.?, 0, std.mem.sliceAsBytes(sorted));
 }

--- a/utils/swindowzig/examples/voxel/mesher.zig
+++ b/utils/swindowzig/examples/voxel/mesher.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const chunk_mod = @import("chunk.zig");
 const Chunk = chunk_mod.Chunk;
 const BlockType = chunk_mod.BlockType;
+const BlockGetter = chunk_mod.BlockGetter;
 const CHUNK_W = chunk_mod.CHUNK_W;
 const CHUNK_H = chunk_mod.CHUNK_H;
 
@@ -199,6 +200,9 @@ pub const Mesh = struct {
         by: i32,
         bz: i32,
         camera_pos: [3]f32,
+        world_ox: i32,
+        world_oz: i32,
+        getter: BlockGetter,
     ) !void {
         const offsets = [7][3]i32{
             .{ 0, 0, 0 },
@@ -283,13 +287,15 @@ pub const Mesh = struct {
             const pos = unpackBlockIdx(ab);
             const block = chunk.getBlock(pos.x, pos.y, pos.z);
             if (block == .air) continue;
+            const wpx = world_ox + pos.x;
+            const wpz = world_oz + pos.z;
             for ([_]Face{ .px, .nx, .py, .ny, .pz, .nz }) |face| {
-                if (shouldRenderFace(chunk, pos.x, pos.y, pos.z, face)) {
+                if (shouldRenderFace(chunk, getter, pos.x, pos.y, pos.z, world_ox, world_oz, face)) {
                     try addQuad(
                         self,
-                        @floatFromInt(pos.x),
+                        @floatFromInt(wpx),
                         @floatFromInt(pos.y),
-                        @floatFromInt(pos.z),
+                        @floatFromInt(wpz),
                         face,
                         block,
                         ab,
@@ -387,13 +393,20 @@ const face_offsets = [_][3]i32{
     .{ 0, 0, -1 }, // -Z
 };
 
-/// Check if a face should be rendered (neighbor is air or out of bounds)
-fn shouldRenderFace(chunk: *const Chunk, x: i32, y: i32, z: i32, face: Face) bool {
+/// Fast face-render check. For neighbours within this chunk's bounds (~92% of cases),
+/// uses direct array access. Only falls back to the world getter for out-of-bounds
+/// neighbours (chunk boundaries), enabling correct cross-chunk face culling.
+fn shouldRenderFace(chunk: *const Chunk, getter: BlockGetter, lx: i32, ly: i32, lz: i32, world_ox: i32, world_oz: i32, face: Face) bool {
     const offset = face_offsets[@intFromEnum(face)];
-    const nx = x + offset[0];
-    const ny = y + offset[1];
-    const nz = z + offset[2];
-    return chunk.getBlock(nx, ny, nz) == .air;
+    const nx = lx + offset[0];
+    const ny = ly + offset[1];
+    const nz = lz + offset[2];
+    // Fast path: neighbour is within this chunk (direct array access, no HashMap)
+    if (nx >= 0 and nx < CHUNK_W and ny >= 0 and ny < CHUNK_H and nz >= 0 and nz < CHUNK_W) {
+        return chunk.blocks[@intCast(nx)][@intCast(ny)][@intCast(nz)] == .air;
+    }
+    // Slow path: neighbour in adjacent chunk — world HashMap lookup
+    return getter.getBlock(world_ox + nx, ny, world_oz + nz) == .air;
 }
 
 /// Add a quad face to the mesh, recording its owning block via block_idx.
@@ -480,7 +493,9 @@ fn addQuad(
 }
 
 /// Full mesh generation from scratch. Use updateForBlockChange for incremental updates.
-pub fn generateMesh(chunk: *const Chunk, mesh: *Mesh) !void {
+/// world_ox/world_oz are the world-space block origin of this chunk.
+/// getter is used for cross-chunk face culling at chunk boundaries.
+pub fn generateMesh(chunk: *const Chunk, mesh: *Mesh, world_ox: i32, world_oz: i32, getter: BlockGetter) !void {
     mesh.clear();
 
     var x: i32 = 0;
@@ -492,14 +507,16 @@ pub fn generateMesh(chunk: *const Chunk, mesh: *Mesh) !void {
                 const block = chunk.getBlock(x, y, z);
                 if (block == .air) continue;
 
+                const block_wx = world_ox + x;
+                const block_wz = world_oz + z;
                 const block_idx = packBlockIdx(x, y, z);
                 for ([_]Face{ .px, .nx, .py, .ny, .pz, .nz }) |face| {
-                    if (shouldRenderFace(chunk, x, y, z, face)) {
+                    if (shouldRenderFace(chunk, getter, x, y, z, world_ox, world_oz, face)) {
                         try addQuad(
                             mesh,
-                            @floatFromInt(x),
+                            @floatFromInt(block_wx),
                             @floatFromInt(y),
-                            @floatFromInt(z),
+                            @floatFromInt(block_wz),
                             face,
                             block,
                             block_idx,

--- a/utils/swindowzig/examples/voxel/player.zig
+++ b/utils/swindowzig/examples/voxel/player.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const chunk_mod = @import("chunk.zig");
 const Chunk = chunk_mod.Chunk;
+const BlockGetter = chunk_mod.BlockGetter;
 const mesher_mod = @import("mesher.zig");
 const VoxelVertex = mesher_mod.VoxelVertex;
 
@@ -49,7 +50,7 @@ pub const Player = struct {
     /// cam_yaw is the camera yaw so horizontal movement aligns with where you're looking.
     pub fn tick(
         self: *Player,
-        chunk: *const Chunk,
+        getter: BlockGetter,
         dt: f32,
         cam_yaw: f32,
         forward_input: f32,
@@ -89,11 +90,11 @@ pub const Player = struct {
             const dz = (sy * forward_input + cy * right_input) * spd * dt;
             const dy: f32 = if (space_held) spd * dt else if (sprint) -spd * dt else 0;
 
-            self.feet_pos[0] = resolveX(chunk, self.feet_pos, self.feet_pos[0] + dx);
-            self.feet_pos[2] = resolveZ(chunk, self.feet_pos, self.feet_pos[2] + dz);
+            self.feet_pos[0] = resolveX(getter, self.feet_pos, self.feet_pos[0] + dx);
+            self.feet_pos[2] = resolveZ(getter, self.feet_pos, self.feet_pos[2] + dz);
             const new_y = self.feet_pos[1] + dy;
-            self.feet_pos[1] = resolveY(chunk, self.feet_pos, new_y);
-            self.on_ground = isOnGround(chunk, self.feet_pos);
+            self.feet_pos[1] = resolveY(getter, self.feet_pos, new_y);
+            self.on_ground = isOnGround(getter, self.feet_pos);
 
             // Land on solid ground → exit fly mode automatically.
             if (self.on_ground and !space_held) {
@@ -127,16 +128,16 @@ pub const Player = struct {
 
             // Resolve Y first (ground/ceiling), then X/Z.
             const new_y = self.feet_pos[1] + dy;
-            const resolved_y = resolveY(chunk, self.feet_pos, new_y);
+            const resolved_y = resolveY(getter, self.feet_pos, new_y);
             if (dy > 0 and resolved_y < new_y - 0.001) {
                 self.velocity[1] = 0; // hit ceiling
             }
             self.feet_pos[1] = resolved_y;
 
-            self.feet_pos[0] = resolveX(chunk, self.feet_pos, self.feet_pos[0] + dx);
-            self.feet_pos[2] = resolveZ(chunk, self.feet_pos, self.feet_pos[2] + dz);
+            self.feet_pos[0] = resolveX(getter, self.feet_pos, self.feet_pos[0] + dx);
+            self.feet_pos[2] = resolveZ(getter, self.feet_pos, self.feet_pos[2] + dz);
 
-            self.on_ground = isOnGround(chunk, self.feet_pos);
+            self.on_ground = isOnGround(getter, self.feet_pos);
         }
     }
 };
@@ -148,7 +149,7 @@ pub const Player = struct {
 const EPS: f32 = 0.001;
 
 /// True when there is a solid block in the column directly below the player's feet.
-fn isOnGround(chunk: *const Chunk, pos: [3]f32) bool {
+fn isOnGround(getter: BlockGetter, pos: [3]f32) bool {
     const x0: i32 = @intFromFloat(std.math.floor(pos[0] - PLAYER_RADIUS + EPS));
     const x1: i32 = @intFromFloat(std.math.floor(pos[0] + PLAYER_RADIUS - EPS));
     const z0: i32 = @intFromFloat(std.math.floor(pos[2] - PLAYER_RADIUS + EPS));
@@ -160,14 +161,14 @@ fn isOnGround(chunk: *const Chunk, pos: [3]f32) bool {
     while (xi <= x1) : (xi += 1) {
         var zi = z0;
         while (zi <= z1) : (zi += 1) {
-            if (chunk.getBlock(xi, by, zi) != .air) return true;
+            if (getter.getBlock(xi, by, zi) != .air) return true;
         }
     }
     return false;
 }
 
 /// Resolve Y movement: sweep feet (moving down) or head (moving up) against blocks.
-fn resolveY(chunk: *const Chunk, pos: [3]f32, new_y: f32) f32 {
+fn resolveY(getter: BlockGetter, pos: [3]f32, new_y: f32) f32 {
     if (new_y == pos[1]) return new_y;
 
     const x0: i32 = @intFromFloat(std.math.floor(pos[0] - PLAYER_RADIUS + EPS));
@@ -182,7 +183,7 @@ fn resolveY(chunk: *const Chunk, pos: [3]f32, new_y: f32) f32 {
         while (xi <= x1) : (xi += 1) {
             var zi = z0;
             while (zi <= z1) : (zi += 1) {
-                if (chunk.getBlock(xi, by, zi) != .air) {
+                if (getter.getBlock(xi, by, zi) != .air) {
                     // Block top is at by+1; stand feet there.
                     return @as(f32, @floatFromInt(by)) + 1.0;
                 }
@@ -195,7 +196,7 @@ fn resolveY(chunk: *const Chunk, pos: [3]f32, new_y: f32) f32 {
         while (xi <= x1) : (xi += 1) {
             var zi = z0;
             while (zi <= z1) : (zi += 1) {
-                if (chunk.getBlock(xi, head_y, zi) != .air) {
+                if (getter.getBlock(xi, head_y, zi) != .air) {
                     // Block bottom is at head_y; feet go to head_y - HEIGHT.
                     return @as(f32, @floatFromInt(head_y)) - PLAYER_HEIGHT;
                 }
@@ -206,7 +207,7 @@ fn resolveY(chunk: *const Chunk, pos: [3]f32, new_y: f32) f32 {
 }
 
 /// Resolve X movement: sweep the leading edge against blocks.
-fn resolveX(chunk: *const Chunk, pos: [3]f32, new_x: f32) f32 {
+fn resolveX(getter: BlockGetter, pos: [3]f32, new_x: f32) f32 {
     if (new_x == pos[0]) return new_x;
 
     const y0: i32 = @intFromFloat(std.math.floor(pos[1] + EPS));
@@ -220,7 +221,7 @@ fn resolveX(chunk: *const Chunk, pos: [3]f32, new_x: f32) f32 {
         while (yi <= y1) : (yi += 1) {
             var zi = z0;
             while (zi <= z1) : (zi += 1) {
-                if (chunk.getBlock(bx, yi, zi) != .air) {
+                if (getter.getBlock(bx, yi, zi) != .air) {
                     return @as(f32, @floatFromInt(bx)) - PLAYER_RADIUS;
                 }
             }
@@ -231,7 +232,7 @@ fn resolveX(chunk: *const Chunk, pos: [3]f32, new_x: f32) f32 {
         while (yi <= y1) : (yi += 1) {
             var zi = z0;
             while (zi <= z1) : (zi += 1) {
-                if (chunk.getBlock(bx, yi, zi) != .air) {
+                if (getter.getBlock(bx, yi, zi) != .air) {
                     return @as(f32, @floatFromInt(bx + 1)) + PLAYER_RADIUS;
                 }
             }
@@ -241,7 +242,7 @@ fn resolveX(chunk: *const Chunk, pos: [3]f32, new_x: f32) f32 {
 }
 
 /// Resolve Z movement: sweep the leading edge against blocks.
-fn resolveZ(chunk: *const Chunk, pos: [3]f32, new_z: f32) f32 {
+fn resolveZ(getter: BlockGetter, pos: [3]f32, new_z: f32) f32 {
     if (new_z == pos[2]) return new_z;
 
     const y0: i32 = @intFromFloat(std.math.floor(pos[1] + EPS));
@@ -255,7 +256,7 @@ fn resolveZ(chunk: *const Chunk, pos: [3]f32, new_z: f32) f32 {
         while (yi <= y1) : (yi += 1) {
             var xi = x0;
             while (xi <= x1) : (xi += 1) {
-                if (chunk.getBlock(xi, yi, bz) != .air) {
+                if (getter.getBlock(xi, yi, bz) != .air) {
                     return @as(f32, @floatFromInt(bz)) - PLAYER_RADIUS;
                 }
             }
@@ -266,7 +267,7 @@ fn resolveZ(chunk: *const Chunk, pos: [3]f32, new_z: f32) f32 {
         while (yi <= y1) : (yi += 1) {
             var xi = x0;
             while (xi <= x1) : (xi += 1) {
-                if (chunk.getBlock(xi, yi, bz) != .air) {
+                if (getter.getBlock(xi, yi, bz) != .air) {
                     return @as(f32, @floatFromInt(bz + 1)) + PLAYER_RADIUS;
                 }
             }

--- a/utils/swindowzig/examples/voxel/world.zig
+++ b/utils/swindowzig/examples/voxel/world.zig
@@ -1,0 +1,222 @@
+const std = @import("std");
+const chunk_mod = @import("chunk.zig");
+const mesher_mod = @import("mesher.zig");
+const Chunk = chunk_mod.Chunk;
+const Mesh = mesher_mod.Mesh;
+
+/// Render distance in chunks (circular radius).
+/// TODO: expose as an in-game setting via the HUD.
+pub const RENDER_DISTANCE: i32 = 6;
+
+/// Terrain-generation passes per tick. Keeps tick time bounded while loading.
+const CHUNKS_PER_TICK: usize = 2;
+
+/// A RegionAnchor requests that all chunks within RENDER_DISTANCE be loaded.
+/// Currently only the player satisfies this. Future entities (beacons, spectators,
+/// off-screen simulations) can provide anchors to extend the loaded region.
+pub const RegionAnchor = struct {
+    position: [3]f32,
+};
+
+/// Convert a world-space block coordinate to a chunk-grid coordinate.
+pub fn chunkCoordOf(world_coord: i32) i32 {
+    return @divFloor(world_coord, chunk_mod.CHUNK_W);
+}
+
+pub const ChunkKey = struct {
+    cx: i32,
+    cz: i32,
+
+    pub const HashContext = struct {
+        pub fn hash(_: HashContext, k: ChunkKey) u64 {
+            var h = std.hash.Wyhash.init(0);
+            h.update(std.mem.asBytes(&k.cx));
+            h.update(std.mem.asBytes(&k.cz));
+            return h.final();
+        }
+        pub fn eql(_: HashContext, a: ChunkKey, b: ChunkKey) bool {
+            return a.cx == b.cx and a.cz == b.cz;
+        }
+    };
+};
+
+const ChunkOffset = struct { dx: i32, dz: i32 };
+
+pub const ChunkMap = std.HashMap(ChunkKey, *LoadedChunk, ChunkKey.HashContext, std.hash_map.default_max_load_percentage);
+
+/// A single loaded chunk: terrain data + mesh + dirty flags.
+pub const LoadedChunk = struct {
+    chunk: Chunk,
+    mesh: Mesh,
+    cx: i32,
+    cz: i32,
+    /// True when the mesh needs full regeneration (just loaded, or neighbor arrived).
+    mesh_dirty: bool,
+    /// True when mesh was changed incrementally and GPU buffers need re-upload.
+    mesh_incremental_dirty: bool,
+
+    pub fn init(allocator: std.mem.Allocator, cx: i32, cz: i32) LoadedChunk {
+        return .{
+            .chunk = Chunk.init(),
+            .mesh = Mesh.init(allocator),
+            .cx = cx,
+            .cz = cz,
+            .mesh_dirty = true,
+            .mesh_incremental_dirty = false,
+        };
+    }
+
+    pub fn deinit(self: *LoadedChunk) void {
+        self.mesh.deinit();
+    }
+
+    /// World-space X origin of this chunk in block units.
+    pub fn worldX(self: *const LoadedChunk) i32 {
+        return self.cx * chunk_mod.CHUNK_W;
+    }
+
+    /// World-space Z origin of this chunk in block units.
+    pub fn worldZ(self: *const LoadedChunk) i32 {
+        return self.cz * chunk_mod.CHUNK_W;
+    }
+
+    /// World-space X origin as f32.
+    pub fn worldXf(self: *const LoadedChunk) f32 {
+        return @as(f32, @floatFromInt(self.worldX()));
+    }
+
+    /// World-space Z origin as f32.
+    pub fn worldZf(self: *const LoadedChunk) f32 {
+        return @as(f32, @floatFromInt(self.worldZ()));
+    }
+};
+
+pub const World = struct {
+    allocator: std.mem.Allocator,
+    chunks: ChunkMap,
+    /// Pre-computed (dx, dz) offsets sorted by distance from origin (innermost first).
+    /// Built once at init; reused every tick.
+    spiral_offsets: []ChunkOffset,
+
+    pub fn init(allocator: std.mem.Allocator) !World {
+        return .{
+            .allocator = allocator,
+            .chunks = ChunkMap.init(allocator),
+            .spiral_offsets = try buildSpiralOffsets(allocator, RENDER_DISTANCE),
+        };
+    }
+
+    pub fn deinit(self: *World) void {
+        var it = self.chunks.valueIterator();
+        while (it.next()) |lc_ptr| {
+            lc_ptr.*.deinit();
+            self.allocator.destroy(lc_ptr.*);
+        }
+        self.chunks.deinit();
+        self.allocator.free(self.spiral_offsets);
+    }
+
+    /// Update chunk loading for the given anchors.
+    /// Loads up to CHUNKS_PER_TICK new chunks per call, innermost-first.
+    /// When a new chunk is loaded, adjacent already-loaded chunks are re-meshed
+    /// so their boundary faces are correctly culled against the new neighbour.
+    /// Call this from voxelTick once per tick.
+    pub fn update(self: *World, anchors: []const RegionAnchor) !void {
+        var loaded_this_tick: usize = 0;
+
+        outer: for (self.spiral_offsets) |off| {
+            if (loaded_this_tick >= CHUNKS_PER_TICK) break;
+
+            for (anchors) |anchor| {
+                if (loaded_this_tick >= CHUNKS_PER_TICK) break :outer;
+
+                const anchor_cx = chunkCoordOf(@as(i32, @intFromFloat(@floor(anchor.position[0]))));
+                const anchor_cz = chunkCoordOf(@as(i32, @intFromFloat(@floor(anchor.position[2]))));
+                const key = ChunkKey{ .cx = anchor_cx + off.dx, .cz = anchor_cz + off.dz };
+
+                if (!self.chunks.contains(key)) {
+                    const lc = try self.allocator.create(LoadedChunk);
+                    lc.* = LoadedChunk.init(self.allocator, key.cx, key.cz);
+                    lc.chunk.generateTerrain();
+                    try self.chunks.put(key, lc);
+                    loaded_this_tick += 1;
+
+                    // Re-mesh adjacent already-loaded chunks so their boundary faces
+                    // are re-evaluated against this new neighbour.
+                    const adjacent = [_]ChunkKey{
+                        .{ .cx = key.cx - 1, .cz = key.cz },
+                        .{ .cx = key.cx + 1, .cz = key.cz },
+                        .{ .cx = key.cx, .cz = key.cz - 1 },
+                        .{ .cx = key.cx, .cz = key.cz + 1 },
+                    };
+                    for (adjacent) |nk| {
+                        if (self.chunks.getPtr(nk)) |nlc_ptr| {
+                            nlc_ptr.*.mesh_dirty = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Get a block at world-space coordinates. Returns .air for unloaded chunks.
+    pub fn getBlock(self: *const World, wx: i32, wy: i32, wz: i32) chunk_mod.BlockType {
+        const cx = chunkCoordOf(wx);
+        const cz = chunkCoordOf(wz);
+        const lc = self.chunks.get(.{ .cx = cx, .cz = cz }) orelse return .air;
+        const lx = wx - cx * chunk_mod.CHUNK_W;
+        const lz = wz - cz * chunk_mod.CHUNK_W;
+        return lc.chunk.getBlock(lx, wy, lz);
+    }
+
+    /// Set a block at world-space coordinates. Returns false if the chunk is unloaded.
+    pub fn setBlock(self: *World, wx: i32, wy: i32, wz: i32, block: chunk_mod.BlockType) bool {
+        const cx = chunkCoordOf(wx);
+        const cz = chunkCoordOf(wz);
+        const lc_ptr = self.chunks.getPtr(.{ .cx = cx, .cz = cz }) orelse return false;
+        const lx = wx - cx * chunk_mod.CHUNK_W;
+        const lz = wz - cz * chunk_mod.CHUNK_W;
+        lc_ptr.*.chunk.setBlock(lx, wy, lz, block);
+        return true;
+    }
+
+    /// Get the LoadedChunk containing the given world block coordinate.
+    pub fn getChunkAtBlock(self: *World, wx: i32, wz: i32) ?*LoadedChunk {
+        return self.chunks.get(.{ .cx = chunkCoordOf(wx), .cz = chunkCoordOf(wz) });
+    }
+
+    /// Returns a BlockGetter backed by this World (queries world coords).
+    pub fn asBlockGetter(self: *const World) chunk_mod.BlockGetter {
+        return .{
+            .ctx = self,
+            .getFn = struct {
+                fn get(ctx: *const anyopaque, x: i32, y: i32, z: i32) chunk_mod.BlockType {
+                    return @as(*const World, @ptrCast(@alignCast(ctx))).getBlock(x, y, z);
+                }
+            }.get,
+        };
+    }
+};
+
+fn buildSpiralOffsets(allocator: std.mem.Allocator, r: i32) ![]ChunkOffset {
+    var offsets = std.ArrayList(ChunkOffset){};
+    defer offsets.deinit(allocator);
+
+    var dz: i32 = -r;
+    while (dz <= r) : (dz += 1) {
+        var dx: i32 = -r;
+        while (dx <= r) : (dx += 1) {
+            if (dx * dx + dz * dz <= r * r) {
+                try offsets.append(allocator, .{ .dx = dx, .dz = dz });
+            }
+        }
+    }
+
+    std.mem.sort(ChunkOffset, offsets.items, {}, struct {
+        fn lt(_: void, a: ChunkOffset, b: ChunkOffset) bool {
+            return (a.dx * a.dx + a.dz * a.dz) < (b.dx * b.dx + b.dz * b.dz);
+        }
+    }.lt);
+
+    return offsets.toOwnedSlice(allocator);
+}


### PR DESCRIPTION
…tion

Replaces the single-chunk setup with a proper multi-chunk world system.

World system (world.zig):
- RegionAnchor struct: anything with a world position that requests chunk loading. Currently only the player satisfies this; designed to extend to beacons, spectators, etc. in future.
- World struct: manages loaded chunks via ChunkMap, loads up to 2 chunks per tick in spiral (innermost-first) order around each anchor.
- RENDER_DISTANCE = 6 constant (circular chunk radius, ~113 chunks total). TODO: expose as in-game setting.
- When a new chunk loads, adjacent already-loaded chunks are marked dirty so their boundary faces re-cull against the new neighbour.

Mesher:
- generateMesh / updateForBlockChange accept world_ox/world_oz offsets so vertex positions are in world space (required for multi-chunk rendering).
- Cross-chunk face culling via BlockGetter world query at boundaries.
- Fast path: for ~92% of faces (non-boundary neighbours), uses direct array access instead of world HashMap lookup. 130ms → 23ms per full mesh gen.

Player physics (player.zig):
- All collision helpers now accept BlockGetter instead of *const Chunk, enabling physics to work across chunk boundaries.

Rendering (main.zig):
- Per-chunk GPU buffer pairs (vertex + index), allocated on first upload.
- Rate-limited mesh generation: 1 mesh gen per render frame to keep frame time bounded while the world loads progressively.
- Chunks drawn back-to-front (painter's algorithm at chunk level).
- Chunk border wireframe in debug mode follows the player's current chunk.