### PR TITLE
[SEAN-6] feat: add auto-label PR and stale issue workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,47 @@
+# Maps path globs to labels for actions/labeler
+# Labels must already exist in the repo before they can be applied
+
+seanmizen.com:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/seanmizen.com/**'
+
+carolinemizen.art:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/carolinemizen.art/**'
+
+seanscards:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/seanscards/**'
+
+planning-poker:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/planning-poker/**'
+
+converter:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/converter/**'
+
+gosniff:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/gosniff/**'
+
+minecraft:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/minecraft.seanmizen.com/**'
+
+tty-dashboard:
+  - changed-files:
+      - any-glob-to-any-file: 'utils/tty-dashboard/**'
+
+fly-io:
+  - changed-files:
+      - any-glob-to-any-file: 'utils/fly-io/**'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file: 'docs/**'
+      - any-glob-to-any-file: '*.md'

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,20 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: Auto-label by changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+name: Mark Stale Issues and PRs
+
+on:
+  schedule:
+    # Run daily at 02:00 UTC
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Stale issue/PR cleanup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues: warn after 21 days, close after 30 days of inactivity
+          days-before-stale: 21
+          days-before-close: 9
+
+          stale-issue-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            any activity in the last 21 days. It will be closed in 9 days if no
+            further activity occurs.
+
+          close-issue-message: >
+            This issue was automatically closed because it has been stale for 30 days
+            with no activity.
+
+          # PRs: same schedule
+          stale-pr-label: stale
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has
+            not had any activity in the last 21 days. It will be closed in 9 days if
+            no further activity occurs.
+
+          close-pr-message: >
+            This pull request was automatically closed because it has been stale for
+            30 days with no activity.
+
+          # Exempt labels — never stale these
+          exempt-issue-labels: 'P0,in-progress,ready'
+          exempt-pr-labels: 'P0,in-progress,ready'


### PR DESCRIPTION
Closes #6

## Summary
- Add `.github/workflows/label-pr.yml` using `actions/labeler@v5` to auto-label PRs based on changed files
- Add `.github/labeler.yml` mapping path globs to sub-project labels (seanmizen.com, carolinemizen.art, seanscards, planning-poker, converter, gosniff, minecraft, tty-dashboard, fly-io, ci, docs)
- Add `.github/workflows/stale.yml` using `actions/stale@v9` (warn at 21d, close at 30d), exempting `P0`, `in-progress`, and `ready` labels

## Test plan
- [ ] Open a test PR touching an app path and verify the labeler workflow runs and applies the correct label
- [ ] Verify stale workflow config matches acceptance criteria (warn 21d, close 30d, correct exemptions)
- [ ] Trigger `workflow_dispatch` on stale.yml to dry-run without waiting for cron schedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)