### PR TITLE
[SEAN-5] feat: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,77 @@
+name: Bug
+description: Report a bug or unexpected behaviour
+title: "[SEAN-???] fix: "
+labels: ["backlog", "bug"]
+body:
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps needed to trigger the bug.
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+      description: What should happen?
+      placeholder: Describe what you expected to see.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+      description: What actually happens?
+      placeholder: Describe what you actually observed. Paste error messages or stack traces here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Checklist of conditions that must be true for this bug to be considered fixed.
+      placeholder: |
+        - [ ] The bug no longer reproduces on steps above
+        - [ ] No regressions introduced
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_likely_touched
+    attributes:
+      label: Files Likely Touched
+      description: List files or directories expected to be created or modified.
+      placeholder: |
+        - `apps/my-app/src/components/Foo.tsx`
+        - `apps/my-app/src/utils/bar.ts`
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - Critical / blocking
+        - P1 - High
+        - P2 - Medium
+        - P3 - Low / nice-to-have
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Environment details, screenshots, related issues, or any other context.
+      placeholder: Optional — leave blank if nothing to add.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,56 @@
+name: Chore
+description: Maintenance, refactoring, tooling, or dependency updates
+title: "[SEAN-???] chore: "
+labels: ["backlog", "chore"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this maintenance work needed?
+      placeholder: Describe what needs cleaning up, updating, or improving and why.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Checklist of conditions that must be true for this chore to be considered done.
+      placeholder: |
+        - [ ] Criterion one
+        - [ ] Criterion two
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_likely_touched
+    attributes:
+      label: Files Likely Touched
+      description: List files or directories expected to be created or modified.
+      placeholder: |
+        - `package.json`
+        - `apps/my-app/dockerfile`
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - Critical / blocking
+        - P1 - High
+        - P2 - Medium
+        - P3 - Low / nice-to-have
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Links to docs, related issues, or any other relevant context.
+      placeholder: Optional — leave blank if nothing to add.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,57 @@
+name: Feature
+description: Request a new feature or enhancement
+title: "[SEAN-???] feat: "
+labels: ["backlog"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this feature needed? What problem does it solve?
+      placeholder: Describe the motivation and background for this feature.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Checklist of conditions that must be true for this issue to be considered done.
+      placeholder: |
+        - [ ] Criterion one
+        - [ ] Criterion two
+        - [ ] Criterion three
+    validations:
+      required: true
+
+  - type: textarea
+    id: files_likely_touched
+    attributes:
+      label: Files Likely Touched
+      description: List files or directories expected to be created or modified.
+      placeholder: |
+        - `apps/my-app/src/components/Foo.tsx` (create)
+        - `apps/my-app/src/routes/bar.ts` (update)
+    validations:
+      required: false
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - P0 - Critical / blocking
+        - P1 - High
+        - P2 - Medium
+        - P3 - Low / nice-to-have
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Any additional context, constraints, design decisions, or links.
+      placeholder: Optional — leave blank if nothing to add.
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,6 +320,23 @@ Always squash-merge PRs. No merge commits, no fast-forward. Squash message: `[SE
 
 One ticket = one branch = one PR. If you discover out-of-scope work, create a new issue — do not do it in the current branch.
 
+### Issue Templates
+
+All issues must be created using the YAML-based GitHub Issue Forms in `.github/ISSUE_TEMPLATE/`:
+
+| Template | File | Use for |
+|---|---|---|
+| Feature | `feature.yml` | New features and enhancements |
+| Bug | `bug.yml` | Unexpected behaviour or regressions |
+| Chore | `chore.yml` | Maintenance, refactoring, dependency updates |
+
+Every template pre-populates the `backlog` label and requires **Acceptance Criteria** and **Priority**. Agents creating issues programmatically must include these same fields (even if not using the web form):
+
+- **Context** (feature/chore) or **Steps to Reproduce + Expected/Actual** (bug)
+- **Acceptance Criteria** — checklist of done conditions
+- **Files Likely Touched** — expected files to create or modify
+- **Priority** — `P0` through `P3`
+
 ### WIP Limits
 
 Cap concurrent `in-progress` issues at 3–5 to prevent merge conflicts between parallel agents.


### PR DESCRIPTION
Closes #5

## Summary
- Adds YAML-based GitHub Issue Forms for `feature`, `bug`, and `chore` issue types in `.github/ISSUE_TEMPLATE/`
- Each template pre-populates relevant labels (`backlog`, `bug`, `chore`) and requires acceptance criteria and priority fields
- Updates `CLAUDE.md` with an Issue Templates section documenting the required fields so agents follow the same structure when creating issues programmatically

## Test plan
- [ ] Visit the repo's "New Issue" page and verify three templates appear: Feature, Bug, Chore
- [ ] Open each template and confirm required fields (Acceptance Criteria, Priority) are present
- [ ] Verify `backlog` label is pre-populated on Feature template, `backlog` + `bug` on Bug, `backlog` + `chore` on Chore
- [ ] Check CLAUDE.md Agile Process section contains the new Issue Templates subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)