### PR TITLE
[SEAN-23] fix: resolve voxel blue-sky rendering — CompareFunction enum mismatch

### DIFF
--- a/utils/swindowzig/CLAUDE.md
+++ b/utils/swindowzig/CLAUDE.md
@@ -82,6 +82,16 @@ with "Texture binding N expects dimension = D1, but given a view with dimension 
 `createBindGroupLayout` now uses explicit switch maps for both `.texture.view_dimension`
 and `.storage_texture.view_dimension`. Do not use raw `@intFromEnum` for these.
 
+### CompareFunction enum mismatch (fixed in gpu.zig — createRenderPipeline)
+`types.CompareFunction` starts at 0 (`never=0, less=1, …, always=7`), but native
+`WGPUCompareFunction` has `undefined=0, never=1, less=2, …, always=8`. Additionally,
+the order of `equal`, `not_equal`, and `greater_equal` differs between the two enums.
+Raw `@intFromEnum` would map `.less→1 = never` — silently making the depth test always
+reject every fragment (blank sky-only output). `createRenderPipeline` now uses
+`toNativeCompareFunction()`, an explicit named switch, for all three CompareFunction
+fields (depth_compare, stencil_front.compare, stencil_back.compare).
+Do not use raw `@intFromEnum` for CompareFunction conversions.
+
 ### Hardware depth testing (macOS/Metal)
 Hardware depth testing is **enabled** in the voxel pipeline (`depth24plus`,
 `depth_write_enabled = true`, `depth_compare = .less`). The Metal crash

--- a/utils/swindowzig/examples/voxel/main.zig
+++ b/utils/swindowzig/examples/voxel/main.zig
@@ -3497,7 +3497,6 @@ fn voxelRender(ctx: *sw.Context) !void {
         pass.setIndexBuffer(cg.index_buffer.?, .uint32, 0, lc.mesh.indices.items.len * @sizeOf(u32));
         pass.drawIndexed(@intCast(lc.mesh.indices.items.len), 1, 0, 0, 0);
     }
-
     // =========================================================================
     // Player hitbox cylinder (drawn after voxels; no face culling so always visible)
     // =========================================================================

--- a/utils/swindowzig/libs/sw_gpu/src/gpu.zig
+++ b/utils/swindowzig/libs/sw_gpu/src/gpu.zig
@@ -56,6 +56,24 @@ const DeviceRequestResult = if (!is_wasm) struct {
     device: native.WGPUDevice = null,
 } else struct {};
 
+/// Map types.CompareFunction to WGPUCompareFunction.
+/// The Zig types enum starts at 0 (never=0), but WGPUCompareFunction has
+/// undefined=0 and never=1, so a raw @intFromEnum cast is off by one.
+/// Additionally, `equal`, `not_equal`, and `greater_equal` are in a
+/// different order between the two enums, so only a named switch is safe.
+fn toNativeCompareFunction(cf: types.CompareFunction) native.WGPUCompareFunction {
+    return switch (cf) {
+        .never => .never,
+        .less => .less,
+        .equal => .equal,
+        .less_equal => .less_equal,
+        .greater => .greater,
+        .not_equal => .not_equal,
+        .greater_equal => .greater_equal,
+        .always => .always,
+    };
+}
+
 fn adapterRequestCallback(
     status: native.WGPURequestAdapterStatus,
     adapter: native.WGPUAdapter,
@@ -955,16 +973,16 @@ pub const GPU = struct {
                 depth_stencil_state_storage = std.mem.zeroes(native.WGPUDepthStencilState);
                 depth_stencil_state_storage.format = @enumFromInt(@intFromEnum(depth_stencil.format));
                 depth_stencil_state_storage.depth_write_enabled = if (depth_stencil.depth_write_enabled) @as(u32, 1) else 0;
-                depth_stencil_state_storage.depth_compare = @enumFromInt(@intFromEnum(depth_stencil.depth_compare));
+                depth_stencil_state_storage.depth_compare = toNativeCompareFunction(depth_stencil.depth_compare);
 
                 // Stencil front state
-                depth_stencil_state_storage.stencil_front.compare = @enumFromInt(@intFromEnum(depth_stencil.stencil_front.compare));
+                depth_stencil_state_storage.stencil_front.compare = toNativeCompareFunction(depth_stencil.stencil_front.compare);
                 depth_stencil_state_storage.stencil_front.fail_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_front.fail_op));
                 depth_stencil_state_storage.stencil_front.depth_fail_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_front.depth_fail_op));
                 depth_stencil_state_storage.stencil_front.pass_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_front.pass_op));
 
                 // Stencil back state
-                depth_stencil_state_storage.stencil_back.compare = @enumFromInt(@intFromEnum(depth_stencil.stencil_back.compare));
+                depth_stencil_state_storage.stencil_back.compare = toNativeCompareFunction(depth_stencil.stencil_back.compare);
                 depth_stencil_state_storage.stencil_back.fail_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_back.fail_op));
                 depth_stencil_state_storage.stencil_back.depth_fail_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_back.depth_fail_op));
                 depth_stencil_state_storage.stencil_back.pass_op = @enumFromInt(@intFromEnum(depth_stencil.stencil_back.pass_op));


### PR DESCRIPTION
## Summary

- `types.CompareFunction` starts at 0 but `WGPUCompareFunction` has `undefined=0` making every value off-by-one. Raw `@intFromEnum(.less)` → native `1` = `never`, so every depth test silently rejected every fragment — rendering nothing but the sky clear colour.
- Added `toNativeCompareFunction()` with an explicit named switch (same pattern as IndexFormat and TextureViewDimension fixes already in CLAUDE.md).
- Documents the bug in CLAUDE.md's Critical Lessons section.

## Test plan

- [x] `zig build native -Dexample=voxel` — clean compile
- [x] `./zig-out/bin/voxel --headless --tas examples/voxel/framespike.tas` — exits 0
- [x] `timeout 5 ./zig-out/bin/voxel` — no crash, terrain visible
- [x] Dump-frame PPM confirms terrain pixels (non-sky colors visible)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)