### PR TITLE
[SEAN-12] docs: add workflow SOP reference documents

### DIFF
--- a/.claude/workflows/new-ticket.md
+++ b/.claude/workflows/new-ticket.md
@@ -1,0 +1,44 @@
+# Workflow: Creating a New Ticket
+
+Reference: [AGENTS.md](../../AGENTS.md) for conventions.
+
+## Checklist
+
+1. Identify the correct issue template:
+   - Feature/enhancement → `feature.yml`
+   - Bug/regression → `bug.yml`
+   - Maintenance/refactor → `chore.yml`
+
+2. Create the issue via `gh`:
+   ```bash
+   gh issue create --repo seanmizen/seanorepo \
+     --title "{short description}" \
+     --body "$(cat <<'EOF'
+   ## Context
+   {why this work is needed}
+
+   ## Acceptance Criteria
+   - [ ] {done condition 1}
+   - [ ] {done condition 2}
+
+   ## Files Likely Touched
+   - `{path/to/file}` (create/modify)
+
+   ## Priority
+   P{0-3}
+   EOF
+   )" \
+     --label "backlog"
+   ```
+
+3. Confirm the issue was created and has:
+   - `backlog` label
+   - Acceptance Criteria checklist
+   - Priority field (`P0`–`P3`)
+   - Files Likely Touched section
+
+4. If the issue is ready to be worked on immediately, move it to `ready`:
+   ```bash
+   gh issue edit {number} --repo seanmizen/seanorepo \
+     --add-label "ready" --remove-label "backlog"
+   ```

--- a/.claude/workflows/start-work.md
+++ b/.claude/workflows/start-work.md
@@ -1,0 +1,28 @@
+# Workflow: Starting Work on a Ticket
+
+Reference: [AGENTS.md](../../AGENTS.md) for conventions.
+
+## Checklist
+
+1. Check WIP limit — no more than 3–5 issues `in-progress` at once:
+   ```bash
+   gh issue list --repo seanmizen/seanorepo --label "in-progress" --state open
+   ```
+
+2. Move the issue from `ready` to `in-progress`:
+   ```bash
+   gh issue edit {number} --repo seanmizen/seanorepo \
+     --add-label "in-progress" --remove-label "ready"
+   ```
+
+3. Create a branch from `main` using the correct naming convention:
+   ```bash
+   git checkout main && git pull
+   git checkout -b SEAN-{number}/{short-description}
+   ```
+   - Lowercase, hyphenated, max 5 words
+   - Must include ticket ref (e.g. `SEAN-42/fix-hover-flicker`)
+
+4. Read the issue acceptance criteria carefully before writing any code.
+
+5. Do NOT start any out-of-scope work discovered during implementation — create a new issue instead (see AGENTS.md).

--- a/.claude/workflows/submit-pr.md
+++ b/.claude/workflows/submit-pr.md
@@ -1,0 +1,55 @@
+# Workflow: Submitting a PR
+
+Reference: [AGENTS.md](../../AGENTS.md) for conventions.
+
+## Checklist
+
+1. Run code quality checks from monorepo root:
+   ```bash
+   yarn fix
+   ```
+
+2. If you touched a TypeScript backend project, check for type errors:
+   ```bash
+   tsc --noEmit
+   ```
+
+3. Stage and commit with the correct message format:
+   ```bash
+   git add {files}
+   git commit -m "[SEAN-{number}] {type}: {description}
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+   ```
+   - Never use `--no-verify`
+
+4. Push the branch:
+   ```bash
+   git push -u origin SEAN-{number}/{short-description}
+   ```
+
+5. Open a PR against `main`:
+   ```bash
+   gh pr create --repo seanmizen/seanorepo \
+     --title "[SEAN-{number}] {type}: {description}" \
+     --body "$(cat <<'EOF'
+   Closes #{number}
+
+   ## Summary
+   - {key change 1}
+   - {key change 2}
+
+   ## Test plan
+   - [ ] {test step 1}
+   - [ ] {test step 2}
+   EOF
+   )"
+   ```
+
+6. Move the issue to `in-review`:
+   ```bash
+   gh issue edit {number} --repo seanmizen/seanorepo \
+     --add-label "in-review" --remove-label "in-progress"
+   ```
+
+7. Run the Ignition Phase (see AGENTS.md) — review open PRs and dispatch the next ready issue.

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-yarn commitlint --edit "$1"
+./node_modules/.bin/commitlint --edit "$1"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,6 +288,14 @@ SEAN-{number}/{short-description}
 
 **Agent SOP:** See [`AGENTS.md`](./AGENTS.md) for the authoritative agent workflow — ticket lifecycle, gh CLI commands, branch/commit conventions, out-of-scope handling, and merge conflict resolution.
 
+### Workflow References
+
+Concise per-phase checklists for agents. Not enforced by tooling — just SOPs.
+
+- [`.claude/workflows/new-ticket.md`](./.claude/workflows/new-ticket.md) — steps for creating a well-formed issue
+- [`.claude/workflows/start-work.md`](./.claude/workflows/start-work.md) — checklist for starting a ticket
+- [`.claude/workflows/submit-pr.md`](./.claude/workflows/submit-pr.md) — checklist for opening a PR
+
 **Org:** Sean (CEO) → Dispatch (COO / orchestrator) → Workers (Claude Code agents on individual issues).
 
 ### Ticket Lifecycle


### PR DESCRIPTION
Closes #12

## Summary
- Created `.claude/workflows/new-ticket.md` — steps for creating a well-formed issue
- Created `.claude/workflows/start-work.md` — checklist for starting a ticket
- Created `.claude/workflows/submit-pr.md` — checklist for opening a PR
- Added `### Workflow References` section to `CLAUDE.md` linking all three documents
- Fixed pre-existing bug in `.husky/commit-msg`: changed `yarn commitlint` (no such script) to `./node_modules/.bin/commitlint` so commits don't fail

## Test plan
- [ ] All three workflow files exist under `.claude/workflows/`
- [ ] Each file references AGENTS.md and contains exact `gh` CLI commands
- [ ] CLAUDE.md has a `### Workflow References` note under the Agile Process section