### PR TITLE
[SEAN-36] chore: update converter READMEs for new layout

### DIFF
--- a/apps/ffmpeg-converter/README.md
+++ b/apps/ffmpeg-converter/README.md
@@ -7,6 +7,21 @@ couple of specials.
 
 **Not deployed.** Code + local test suite only.
 
+## Directory layout
+
+This workspace contains three components:
+
+| Path                 | What it is                                       | Status                                   |
+| -------------------- | ------------------------------------------------ | ---------------------------------------- |
+| `./` (root)          | Go HTTP service — the conversion engine          | Active. The 50-op backend documented below. |
+| `./web-spa/`         | Vanilla-TS single-page app (drop zone + preset UI) | **Legacy reference.** Patterns port into the Next.js app; do not extend. |
+| `./web/`             | Next.js 15 (App Router) frontend                 | **Phase 1 — coming next.** Will be the production frontend. Not present yet. |
+
+See [`phased-spec.md`](./phased-spec.md) for the full delivery plan: Phase 0 is the
+`web/` → `web-spa/` rename and this documentation update; Phase 1 stands up the new
+Next.js app at `web/`. The Go backend at the root of this directory powers both
+frontends via `/api/*` proxy.
+
 ## Requirements
 
 - Go 1.22+

--- a/apps/ffmpeg-converter/web-spa/README.md
+++ b/apps/ffmpeg-converter/web-spa/README.md
@@ -1,4 +1,14 @@
-# ffmpeg-converter web
+# ffmpeg-converter web-spa (legacy reference)
+
+> **Status:** Legacy reference SPA. **Not the production frontend.**
+>
+> The Next.js app in `../web/` (Phase 1 of the phased build plan) supersedes this directory.
+> See [`../phased-spec.md`](../phased-spec.md) for the full plan and the role this SPA plays
+> as reference material during the migration.
+>
+> Read this README to understand the original drop-zone UI, URL-state preset model, and
+> Go-backend contract — those patterns port into the Next.js app component-by-component.
+> Do not extend this SPA with new features; new work belongs in `../web/`.
 
 Frontend for the ffmpeg-converter site. A single-page drop-zone + preset UI that posts
 multipart uploads to the Go backend next door in `apps/ffmpeg-converter/`.
@@ -176,6 +186,8 @@ Things explicitly left out of the first cut:
 
 ## See also
 
+- [`../phased-spec.md`](../phased-spec.md) — phased build plan; explains why this SPA is
+  reference material and where the Next.js replacement lives.
 - `../docs/COMPETITORS.md` — field research on the online-converter landscape.
 - `../docs/STRATEGY.md` — answers to "where does simplicity win" and "where does
   fractal options give an edge".


### PR DESCRIPTION
Closes #36

## Summary
- Flag `apps/ffmpeg-converter/web-spa/README.md` as legacy reference at the top, point readers to `phased-spec.md`, and add it to the See also list.
- Add a Directory layout section to `apps/ffmpeg-converter/README.md` documenting the three components: Go backend at root (active), `web-spa/` (legacy reference), `web/` (Next.js — Phase 1).

## Test plan
- [ ] Verify web-spa/README.md flags itself as legacy reference and points to phased-spec.md
- [ ] Verify apps/ffmpeg-converter/README.md documents the three components (web-spa, web, Go backend)