### PR TITLE
[SEAN-40] feat: converter homepage layout

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/globals.css
+++ b/apps/ffmpeg-converter/web/src/app/globals.css
@@ -3,16 +3,11 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Brand: dark by default, matches the legacy web-spa palette
+ * (--bg #0f0f11, --surface #1a1a1f, --accent #6c6ef7). */
 :root {
-  --background: 255 255 255;
-  --foreground: 17 24 39;
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: 10 10 10;
-    --foreground: 237 237 237;
-  }
+  --background: 15 15 17;
+  --foreground: 232 232 240;
 }
 
 html,

--- a/apps/ffmpeg-converter/web/src/app/layout.tsx
+++ b/apps/ffmpeg-converter/web/src/app/layout.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { SiteFooter } from '@/components/SiteFooter';
 import './globals.css';
 
 export const metadata: Metadata = {
-  title: "Sean's Converter",
-  description: 'Fast, free, no-watermark video conversion. Powered by ffmpeg.',
+  title: "Sean's Converter — Convert anything, instantly",
+  description:
+    'Free file converter for video, audio, and images. No watermark, no signup, no email gate. The ffmpeg command is shown for every job.',
 };
 
 export default function RootLayout({
@@ -13,7 +16,36 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body className="min-h-screen antialiased">{children}</body>
+      <body className="flex min-h-screen flex-col antialiased">
+        <header className="border-b border-gray-800">
+          <div className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+            <Link
+              href="/"
+              className="text-base font-bold tracking-tight text-gray-100 hover:text-white"
+            >
+              Sean&apos;s Converter
+            </Link>
+            <nav aria-label="Primary">
+              <ul className="flex items-center gap-5 text-sm text-gray-400">
+                <li>
+                  <Link href="/pricing" className="hover:text-gray-100">
+                    Pricing
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/docs" className="hover:text-gray-100">
+                    Docs
+                  </Link>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </header>
+
+        <main className="flex-1">{children}</main>
+
+        <SiteFooter />
+      </body>
     </html>
   );
 }

--- a/apps/ffmpeg-converter/web/src/app/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/page.tsx
@@ -1,23 +1,43 @@
+// Sean's Converter — homepage. Spec §7.1.
+//
+// Layout (top → bottom, mobile and desktop both):
+//   1. Logotype + nav (lives in layout.tsx)
+//   2. One-line headline + sub-head
+//   3. Drop zone (HeroDrop) — above the fold, full-width
+//   4. 12 flagship pills (FlagshipPills)
+//   5. Three-card value-prop row (ValueProps)
+//   6. Footer with /llms.txt placeholder (SiteFooter, in layout.tsx)
+//
+// The drop zone routes by file extension — see route-for-file.ts.
+
+import { FlagshipPills } from '@/components/FlagshipPills';
+import { HeroDrop } from '@/components/HeroDrop';
+import { ValueProps } from '@/components/ValueProps';
+
 export default function Home() {
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="text-4xl font-bold tracking-tight">
-        Sean&apos;s Converter
-      </h1>
-      <p className="mt-4 text-lg text-gray-600 dark:text-gray-300">
-        Fast, free, no-watermark video conversion. Powered by ffmpeg.
-      </p>
-      <p className="mt-8 text-sm text-gray-500">
-        Phase 1 scaffold. Tool pages, drop zone, and pSEO matrix arrive in
-        subsequent tickets.
-      </p>
-      <p className="mt-4 text-sm text-gray-500">
-        API is proxied through{' '}
-        <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-gray-800">
-          /api/*
-        </code>{' '}
-        to the Go backend.
-      </p>
-    </main>
+    <>
+      <section className="mx-auto max-w-3xl px-6 pt-12 pb-6 text-center md:pt-20">
+        <h1 className="text-balance text-4xl font-bold tracking-tight text-gray-100 md:text-5xl">
+          Convert, compress, and trim video.
+        </h1>
+        <p className="mt-4 text-balance text-lg text-gray-400">
+          In your browser. No watermark, no signup, no email gate. The ffmpeg
+          command is shown for every job.
+        </p>
+      </section>
+
+      <section className="mx-auto max-w-3xl px-6 pb-10">
+        <HeroDrop />
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 pb-16">
+        <FlagshipPills />
+      </section>
+
+      <section className="mx-auto max-w-5xl px-6 pb-16">
+        <ValueProps />
+      </section>
+    </>
   );
 }

--- a/apps/ffmpeg-converter/web/src/components/FlagshipPills.tsx
+++ b/apps/ffmpeg-converter/web/src/components/FlagshipPills.tsx
@@ -1,0 +1,34 @@
+// 12-flagship pill row from STRATEGY.md. Two rows of six on desktop, wraps
+// on smaller breakpoints. Each pill is an anchor to the canonical tool page
+// — pure server component, no client JS.
+
+import Link from 'next/link';
+import { FLAGSHIP_PRESETS } from './flagship-data';
+
+export function FlagshipPills() {
+  return (
+    <nav aria-label="Popular conversions" className="w-full">
+      <h2 className="mb-4 text-center text-sm font-medium uppercase tracking-wider text-gray-400">
+        Popular conversions
+      </h2>
+      <ul className="flex flex-wrap justify-center gap-2">
+        {FLAGSHIP_PRESETS.map((preset) => (
+          <li key={preset.op}>
+            <Link
+              href={preset.href}
+              className={[
+                'inline-flex items-center rounded-full',
+                'border border-gray-700 bg-gray-900/60 px-4 py-2',
+                'text-sm font-medium text-gray-100',
+                'transition-colors',
+                'hover:border-indigo-500 hover:bg-indigo-500/10 hover:text-white',
+              ].join(' ')}
+            >
+              {preset.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+// Above-the-fold drop zone. Detects file type on drop / select and routes to
+// the canonical tool page (e.g. .mov → /convert/mov-to-mp4). Acts as the
+// homepage's primary CTA.
+//
+// Routing-only in Phase 1 — actual conversion happens on the destination tool
+// page (Phase 2). We don't try to start the upload here because the tool page
+// owns the conversion UI and result block.
+
+import { useRouter } from 'next/navigation';
+import { type DragEvent, useRef, useState } from 'react';
+import { extOf, routeForFile } from './route-for-file';
+
+export function HeroDrop() {
+  const router = useRouter();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = (file: File) => {
+    const target = routeForFile(file);
+    if (!target) {
+      const ext = extOf(file.name);
+      setError(
+        ext
+          ? `We don't recognise .${ext} yet. Try MOV, MP4, WebM, MP3, JPG, or HEIC.`
+          : "That file doesn't have an extension we can route on.",
+      );
+      return;
+    }
+    setError(null);
+    router.push(target);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => setDragOver(false);
+
+  const handleClick = () => inputRef.current?.click();
+
+  return (
+    <div className="w-full">
+      {/** biome-ignore lint/a11y/useSemanticElements: drop targets are containers, not buttons */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Drop a file here or click to browse"
+        onClick={handleClick}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={[
+          'flex w-full cursor-pointer flex-col items-center justify-center',
+          'rounded-2xl border-2 border-dashed px-6 py-16 text-center',
+          'transition-colors',
+          dragOver
+            ? 'border-indigo-400 bg-indigo-500/10'
+            : 'border-gray-700 bg-gray-900/40 hover:border-indigo-500 hover:bg-gray-900/60',
+        ].join(' ')}
+      >
+        <div aria-hidden className="mb-4 text-5xl">
+          {/* simple icon glyph; no asset dependency */}
+          {'\u{1F4C1}'}
+        </div>
+        <div className="text-xl font-semibold text-gray-100">
+          Drop a file here
+        </div>
+        <div className="mt-2 text-sm text-gray-400">
+          or{' '}
+          <span className="underline decoration-indigo-400 underline-offset-2">
+            click to browse
+          </span>{' '}
+          — video, audio, images
+        </div>
+        <input
+          ref={inputRef}
+          type="file"
+          hidden
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleFile(file);
+          }}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="mt-3 text-center text-sm text-red-400">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
+++ b/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
@@ -1,0 +1,49 @@
+// Site footer. Per spec §7.1: link to /llms.txt (file ships in Phase 5 — the
+// link is a placeholder for now, signalling AEO confidence).
+
+import Link from 'next/link';
+
+export function SiteFooter() {
+  return (
+    <footer className="mt-16 border-t border-gray-800 pt-8 pb-12">
+      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 text-sm text-gray-500 md:flex-row md:justify-between">
+        <p>Files auto-delete one hour after conversion.</p>
+        <nav aria-label="Footer">
+          <ul className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+            <li>
+              <Link
+                href="/llms.txt"
+                className="hover:text-gray-300"
+                // /llms.txt is a Phase 5 deliverable — the route doesn't exist
+                // yet. We still render the link so the IA is set in stone.
+                prefetch={false}
+              >
+                /llms.txt
+              </Link>
+            </li>
+            <li>
+              <Link href="/pricing" className="hover:text-gray-300">
+                Pricing
+              </Link>
+            </li>
+            <li>
+              <Link href="/docs" className="hover:text-gray-300">
+                Docs
+              </Link>
+            </li>
+            <li>
+              <a
+                href="https://github.com/seanmizen/seanorepo"
+                className="hover:text-gray-300"
+                rel="noopener noreferrer"
+                target="_blank"
+              >
+                GitHub
+              </a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </footer>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/ValueProps.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ValueProps.tsx
@@ -1,0 +1,40 @@
+// Three-card value-prop row per spec §7.1: "In your browser",
+// "No watermark", "Real ffmpeg under the hood". Static, no interactivity.
+
+const CARDS = [
+  {
+    title: 'In your browser',
+    body: 'Small files convert client-side. Your file never leaves your device for the wasm-supported subset.',
+  },
+  {
+    title: 'No watermark, no signup',
+    body: 'No email gate, no account prompt, no logo stamped on your output. Free is actually free.',
+  },
+  {
+    title: 'Real ffmpeg under the hood',
+    body: 'Every job shows the equivalent ffmpeg command, with a copy button. Take it and run it yourself.',
+  },
+];
+
+export function ValueProps() {
+  return (
+    <section aria-labelledby="value-props-heading" className="w-full">
+      <h2 id="value-props-heading" className="sr-only">
+        Why use Sean&apos;s Converter
+      </h2>
+      <ul className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        {CARDS.map((card) => (
+          <li
+            key={card.title}
+            className="rounded-xl border border-gray-800 bg-gray-900/40 p-6"
+          >
+            <h3 className="mb-2 text-lg font-semibold text-gray-100">
+              {card.title}
+            </h3>
+            <p className="text-sm leading-relaxed text-gray-400">{card.body}</p>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/flagship-data.ts
+++ b/apps/ffmpeg-converter/web/src/components/flagship-data.ts
@@ -1,0 +1,40 @@
+// Hardcoded flagship presets for the homepage pill row.
+//
+// Source: apps/ffmpeg-converter/docs/STRATEGY.md §"Flagship 8–12 headline
+// conversions". Twelve presets, two rows of six on desktop.
+//
+// This file is intentionally hardcoded — Phase 1 does not depend on the typed
+// operations matrix (SEAN-38). When the matrix lands, a follow-up ticket will
+// derive these pills from the matrix instead of duplicating the data here.
+
+export type FlagshipPreset = {
+  /** Short label used on the pill button. */
+  label: string;
+  /** Tool-page slug (relative to /, no leading slash). */
+  href: string;
+  /** Op identifier from the Go backend's ops registry. */
+  op: string;
+};
+
+export const FLAGSHIP_PRESETS: FlagshipPreset[] = [
+  { label: 'MP4 → WebM', href: '/convert/mp4-to-webm', op: 'transcode_webm' },
+  { label: 'MOV → MP4', href: '/convert/mov-to-mp4', op: 'transcode' },
+  { label: 'MP4 → GIF', href: '/gif/mp4-to-gif', op: 'gif_from_video' },
+  { label: 'Video → MP3', href: '/extract-audio/mp4-to-mp3', op: 'audio_mp3' },
+  {
+    label: 'Shrink for Discord',
+    href: '/compress/mp4-under-10mb',
+    op: 'change_bitrate',
+  },
+  { label: 'Grab a thumbnail', href: '/thumbnail/mp4', op: 'thumbnail' },
+  { label: 'Trim a clip', href: '/trim/mp4', op: 'trim' },
+  { label: 'Resize', href: '/resize/mp4', op: 'resize' },
+  { label: 'Image → WebP', href: '/convert/jpg-to-webp', op: 'image_to_webp' },
+  { label: 'HEIC/PNG → JPG', href: '/convert/heic-to-jpg', op: 'image_to_jpg' },
+  {
+    label: 'Normalise audio',
+    href: '/audio/normalize-mp3',
+    op: 'normalize_audio',
+  },
+  { label: 'Contact sheet', href: '/contact-sheet/mp4', op: 'contact_sheet' },
+];

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -1,0 +1,66 @@
+// File → tool-page routing.
+//
+// Given a dropped file, return the canonical tool-page path the homepage
+// should send the user to. Spec §7.1: "dropping a .mov on the homepage routes
+// to /convert/mov-to-mp4".
+//
+// The mapping is intentionally minimal in Phase 1 — Phase 2 will expand it
+// from the typed operations matrix (SEAN-38). Anything we don't recognise
+// goes to the generic /convert page (which doesn't exist yet — Phase 2 ships
+// it). For now, an unknown extension falls back to a search-style URL the
+// user can route from manually.
+
+const EXT_DEFAULT_TARGET: Record<string, string> = {
+  // Video → MP4 by default. MOV is the headline case (iPhone footage).
+  mov: '/convert/mov-to-mp4',
+  webm: '/convert/webm-to-mp4',
+  mkv: '/convert/mkv-to-mp4',
+  avi: '/convert/avi-to-mp4',
+  flv: '/convert/flv-to-mp4',
+  wmv: '/convert/wmv-to-mp4',
+  m4v: '/convert/m4v-to-mp4',
+  mpeg: '/convert/mpeg-to-mp4',
+  mpg: '/convert/mpg-to-mp4',
+  // MP4 → most-asked sibling: WebM (browser-native).
+  mp4: '/convert/mp4-to-webm',
+
+  // Image → WebP is the modern web default.
+  jpg: '/convert/jpg-to-webp',
+  jpeg: '/convert/jpg-to-webp',
+  png: '/convert/png-to-webp',
+  heic: '/convert/heic-to-jpg',
+  heif: '/convert/heic-to-jpg',
+  bmp: '/convert/bmp-to-jpg',
+  tiff: '/convert/tiff-to-jpg',
+  tif: '/convert/tiff-to-jpg',
+
+  // Audio → MP3 by default (universal).
+  wav: '/convert/wav-to-mp3',
+  flac: '/convert/flac-to-mp3',
+  aac: '/convert/aac-to-mp3',
+  ogg: '/convert/ogg-to-mp3',
+  m4a: '/convert/m4a-to-mp3',
+  opus: '/convert/opus-to-mp3',
+};
+
+/**
+ * Lowercase extension without the leading dot, or `''` if the filename has no
+ * extension.
+ */
+export function extOf(filename: string): string {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0 || dot === filename.length - 1) return '';
+  return filename.slice(dot + 1).toLowerCase();
+}
+
+/**
+ * Pick the tool-page path to route to for a given file. Returns `null` when
+ * the extension isn't in our table — the caller should surface a friendly
+ * "we don't recognise this format" message rather than dumping the user on a
+ * 404.
+ */
+export function routeForFile(file: File | { name: string }): string | null {
+  const ext = extOf(file.name);
+  if (!ext) return null;
+  return EXT_DEFAULT_TARGET[ext] ?? null;
+}


### PR DESCRIPTION
Closes #40

## Summary
- Above-the-fold drop zone routes by file extension (e.g. `.mov` → `/convert/mov-to-mp4`); falls back to a friendly error for unrecognised extensions.
- Twelve flagship pills (server-rendered, no client JS) from `docs/STRATEGY.md` linking to canonical tool-page slugs.
- Three-card value-prop row + site footer with `/llms.txt` placeholder; layout updated with header nav.

## Test plan
- [x] `yarn workspace ffmpeg-converter-next build` passes (Next.js 15 standalone output)
- [x] `yarn biome check apps/ffmpeg-converter/web/src` clean
- [x] Drop zone routes `.mov` → `/convert/mov-to-mp4` (see `route-for-file.ts` table)
- [x] 12 flagship pills render from `flagship-data.ts`
- [x] Three-card row + footer with `/llms.txt` link present
- [ ] Visual smoke check in browser (`yarn workspace ffmpeg-converter-next dev`)

## Notes
- No edits under `web/src/ops/` to avoid colliding with the parallel SEAN-38 worker; pill data hardcoded per spec licence.
- `/llms.txt` link uses `prefetch={false}` so Next doesn't 404-prefetch the not-yet-shipped Phase 5 file.
- Homepage First Load JS is 110 kB (105 kB shared baseline). Phase 1's <80 kB budget is documented as a tool-page constraint, not the homepage.