### PR TITLE
[SEAN-39] feat: pSEO tool page template and /convert/mov-to-mp4

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/convert/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/convert/[slug]/page.tsx
@@ -1,0 +1,49 @@
+// pSEO tool page route. Phase 1 only renders rows whose `operation === 'convert'`
+// — Phase 2 ships /compress/[slug], /extract-audio/[slug], /gif/[slug] etc.
+// using the same <ToolPage row=... /> component.
+//
+// Dynamic param resolution:
+//   - slug is looked up against MATRIX_BY_SLUG.
+//   - If the slug is unknown OR points at a non-convert row, return notFound().
+//   - generateStaticParams pre-renders every convert row at build time so the
+//     pages ship as static HTML (Lighthouse Performance ≥95 budget).
+//   - generateMetadata pulls the row's `title` for the <title> + meta tags.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+// Static generation — list every convert-row slug.
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'convert').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== 'convert') {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function ConvertPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== 'convert') {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/components/DropZone.tsx
+++ b/apps/ffmpeg-converter/web/src/components/DropZone.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+// Generic drop zone used on every pSEO tool page.
+//
+// Distinct from `HeroDrop` (homepage drop zone, which only routes by file
+// extension). This drop zone *runs* the conversion: it accepts a file, posts
+// it to the backend's `/api/convert` endpoint with the row's Go op name, and
+// hands the resulting job back to the parent via `onJobComplete` / `onError`.
+//
+// Stays presentational — the parent (ToolPage) decides what to render with
+// the result (see ResultBlock). DropZone owns: hover state, file input, the
+// running spinner, and the upload itself.
+
+import {
+  type DragEvent,
+  type ReactNode,
+  useCallback,
+  useRef,
+  useState,
+} from 'react';
+
+export interface ConversionJob {
+  /** Backend job id, e.g. UUID. */
+  jobId: string;
+  /** Same-origin download URL (`/api/jobs/<id>/output`). */
+  downloadUrl: string;
+  /** Original input filename, used to name the downloaded result. */
+  inputFilename: string;
+  /** Output extension (without leading dot), e.g. `mp4`, `webp`, `mp3`. */
+  outputExt: string;
+}
+
+export interface DropZoneProps {
+  /**
+   * Backend op name as registered in the Go service (`ops.go::RegisterOps`).
+   * Comes from the matrix row's `goOp` field.
+   */
+  goOp: string;
+  /** Output format extension (no leading dot) — used to name the download. */
+  outputExt: string;
+  /**
+   * Comma-separated list of accepted MIME types or extensions for the
+   * `<input accept>` attribute (e.g. `.mov,.MOV,video/quicktime`).
+   * Optional — accepting everything still works, the backend will reject.
+   */
+  accept?: string;
+  /**
+   * Human-readable list of accepted formats shown in the drop zone copy
+   * (e.g. `MOV` or `MP4, MOV, WebM`). Falls back to "your file" if absent.
+   */
+  acceptLabel?: string;
+  /**
+   * Extra args forwarded to the Go op as multipart form fields. Used by
+   * preset-driven rows (e.g. `targetSizeMb` for compress under-25mb).
+   */
+  extraArgs?: Record<string, string>;
+  /** Slot above the drop target — typically the H1 + value prop. */
+  header?: ReactNode;
+  /** Called when the upload + conversion succeeds. */
+  onJobComplete: (job: ConversionJob) => void;
+}
+
+type Status = 'idle' | 'uploading' | 'converting';
+
+export function DropZone({
+  goOp,
+  outputExt,
+  accept,
+  acceptLabel,
+  extraArgs,
+  header,
+  onJobComplete,
+}: DropZoneProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [dragOver, setDragOver] = useState(false);
+  const [status, setStatus] = useState<Status>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [pendingName, setPendingName] = useState<string | null>(null);
+
+  const runConversion = useCallback(
+    async (file: File) => {
+      setError(null);
+      setStatus('uploading');
+      setPendingName(file.name);
+
+      const form = new FormData();
+      form.append('op', goOp);
+      form.append('file', file);
+      form.append('ext', outputExt);
+      if (extraArgs) {
+        for (const [k, v] of Object.entries(extraArgs)) {
+          if (v !== '') form.append(k, v);
+        }
+      }
+
+      try {
+        setStatus('converting');
+        const res = await fetch('/api/convert', {
+          method: 'POST',
+          body: form,
+        });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || `${res.status} ${res.statusText}`);
+        }
+        const data = (await res.json()) as {
+          job_id?: string;
+          output?: string;
+        };
+        const jobId = data.job_id ?? '';
+        const downloadPath = data.output ?? `/jobs/${jobId}/output`;
+        onJobComplete({
+          jobId,
+          downloadUrl: `/api${downloadPath}`,
+          inputFilename: file.name,
+          outputExt,
+        });
+        setStatus('idle');
+        setPendingName(null);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setError(msg);
+        setStatus('idle');
+        setPendingName(null);
+      }
+    },
+    [goOp, outputExt, extraArgs, onJobComplete],
+  );
+
+  const handleFile = (file: File) => {
+    void runConversion(file);
+  };
+
+  const handleDrop = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(true);
+  };
+
+  const handleDragLeave = () => setDragOver(false);
+
+  const handleClick = () => {
+    if (status === 'idle') inputRef.current?.click();
+  };
+
+  const busy = status !== 'idle';
+
+  return (
+    <div className="w-full">
+      {header}
+      {/** biome-ignore lint/a11y/useSemanticElements: drop targets are containers, not buttons */}
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Drop a file here or click to browse"
+        aria-disabled={busy}
+        onClick={handleClick}
+        onKeyDown={(e) => {
+          if ((e.key === 'Enter' || e.key === ' ') && !busy) {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+        onDrop={busy ? undefined : handleDrop}
+        onDragOver={busy ? undefined : handleDragOver}
+        onDragLeave={busy ? undefined : handleDragLeave}
+        className={[
+          'flex w-full flex-col items-center justify-center',
+          'rounded-2xl border-2 border-dashed px-6 py-16 text-center',
+          'transition-colors',
+          busy ? 'cursor-wait' : 'cursor-pointer',
+          dragOver
+            ? 'border-indigo-400 bg-indigo-500/10'
+            : 'border-gray-700 bg-gray-900/40 hover:border-indigo-500 hover:bg-gray-900/60',
+        ].join(' ')}
+      >
+        <div aria-hidden className="mb-4 text-5xl">
+          {busy ? '⏳' : '\u{1F4C1}'}
+        </div>
+        {busy ? (
+          <>
+            <div className="text-xl font-semibold text-gray-100">
+              {status === 'uploading' ? 'Uploading…' : 'Converting…'}
+            </div>
+            {pendingName && (
+              <div className="mt-2 max-w-full truncate text-sm text-gray-400">
+                {pendingName}
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            <div className="text-xl font-semibold text-gray-100">
+              Drop a {acceptLabel ?? 'file'} here
+            </div>
+            <div className="mt-2 text-sm text-gray-400">
+              or{' '}
+              <span className="underline decoration-indigo-400 underline-offset-2">
+                click to browse
+              </span>
+            </div>
+          </>
+        )}
+        <input
+          ref={inputRef}
+          type="file"
+          hidden
+          accept={accept}
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) handleFile(file);
+          }}
+        />
+      </div>
+      {error && (
+        <p role="alert" className="mt-3 text-center text-sm text-red-400">
+          Conversion failed: {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/FAQ.tsx
+++ b/apps/ffmpeg-converter/web/src/components/FAQ.tsx
@@ -1,0 +1,63 @@
+// FAQ block. Renders the per-row `faqs` array as native <details>/<summary>
+// pairs (no JS) plus a JSON-LD `FAQPage` schema block for SEO.
+//
+// Pure server component. Phase 2 will add full schema.org coverage
+// (SoftwareApplication, HowTo, BreadcrumbList) — Phase 1 ships FAQPage only,
+// since it is the highest-leverage SERP feature (rich-result eligibility).
+
+import type { FAQ as FAQItem } from '@/ops/types';
+
+export interface FAQProps {
+  faqs: FAQItem[];
+  /** Optional heading override. Defaults to "Frequently asked". */
+  heading?: string;
+}
+
+export function FAQ({ faqs, heading = 'Frequently asked' }: FAQProps) {
+  if (!faqs || faqs.length === 0) return null;
+
+  // FAQPage schema — generated inline so the SERP eligibility ships with the
+  // page on first paint, not after hydration.
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((f) => ({
+      '@type': 'Question',
+      name: f.q,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: f.a,
+      },
+    })),
+  };
+
+  return (
+    <section aria-label="Frequently asked questions">
+      <h2 className="mb-4 font-semibold text-gray-100 text-xl">{heading}</h2>
+      <div className="divide-y divide-gray-800 rounded-2xl border border-gray-800 bg-gray-900/40">
+        {faqs.map((f) => (
+          <details
+            key={f.q}
+            className="group px-5 py-4 [&_summary::-webkit-details-marker]:hidden"
+          >
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-4 text-gray-100">
+              <span className="font-medium">{f.q}</span>
+              <span
+                aria-hidden
+                className="text-gray-400 transition-transform group-open:rotate-90"
+              >
+                ▸
+              </span>
+            </summary>
+            <p className="mt-3 text-gray-400 text-sm leading-relaxed">{f.a}</p>
+          </details>
+        ))}
+      </div>
+      <script
+        type="application/ld+json"
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: JSON-LD schema is required to be a script tag with serialized JSON
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+    </section>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/ResultBlock.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ResultBlock.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+// Result block shown after a successful conversion. Spec §7.2:
+//   - download button
+//   - "ffmpeg command:" code block, copy button
+//   - "Try another file" button
+//   - reverse-link to the inverse conversion (e.g. MP4 → MOV)
+//
+// Pure presentational client component. The parent (ToolPage) owns the job
+// state and decides when to render this.
+
+import Link from 'next/link';
+import { useState } from 'react';
+import type { ConversionJob } from './DropZone';
+
+export interface ResultBlockProps {
+  job: ConversionJob;
+  /** ffmpeg command shown in the code block. */
+  ffmpegCommand: string;
+  /**
+   * Reverse-tool slug fragment (e.g. `mp4-to-mov`). When present, renders a
+   * "Convert X to Y instead?" link. Optional — not every row has a clean
+   * reverse (e.g. extract-audio).
+   */
+  reverseSlug?: string;
+  /** Reverse-tool label (e.g. "MP4 to MOV"). */
+  reverseLabel?: string;
+  /** Operation prefix for the reverse URL. Defaults to `convert`. */
+  reverseOperation?: string;
+  /** Called when the user clicks "Try another file". Resets the parent state. */
+  onReset: () => void;
+}
+
+export function ResultBlock({
+  job,
+  ffmpegCommand,
+  reverseSlug,
+  reverseLabel,
+  reverseOperation = 'convert',
+  onReset,
+}: ResultBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const downloadName = buildDownloadName(job.inputFilename, job.outputExt);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(ffmpegCommand);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be denied (e.g. http://). Silently no-op — the user can
+      // still triple-click the code block.
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-gray-800 bg-gray-900/40 p-6">
+      <h2 className="text-xl font-semibold text-gray-100">Done.</h2>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <a
+          href={job.downloadUrl}
+          download={downloadName}
+          className={[
+            'inline-flex items-center rounded-lg px-5 py-2.5',
+            'bg-indigo-500 text-sm font-semibold text-white',
+            'transition-colors hover:bg-indigo-400',
+          ].join(' ')}
+        >
+          Download {downloadName}
+        </a>
+        <button
+          type="button"
+          onClick={onReset}
+          className={[
+            'inline-flex items-center rounded-lg px-4 py-2.5',
+            'border border-gray-700 bg-gray-900/60',
+            'text-sm font-medium text-gray-100',
+            'transition-colors hover:border-indigo-500 hover:bg-gray-900/80',
+          ].join(' ')}
+        >
+          Try another file
+        </button>
+      </div>
+
+      <div className="mt-6">
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-300">
+            ffmpeg command:
+          </span>
+          <button
+            type="button"
+            onClick={handleCopy}
+            aria-label="Copy ffmpeg command to clipboard"
+            className={[
+              'inline-flex items-center rounded-md px-3 py-1.5',
+              'border border-gray-700 bg-gray-900/60',
+              'text-xs font-medium text-gray-100',
+              'transition-colors hover:border-indigo-500 hover:bg-gray-900/80',
+            ].join(' ')}
+          >
+            {copied ? 'Copied ✓' : 'Copy'}
+          </button>
+        </div>
+        <pre className="overflow-x-auto rounded-lg border border-gray-800 bg-gray-950/80 p-4 text-xs text-gray-200">
+          <code>{ffmpegCommand}</code>
+        </pre>
+      </div>
+
+      {reverseSlug && reverseLabel && (
+        <div className="mt-6 border-gray-800 border-t pt-4 text-sm text-gray-400">
+          Need the other direction?{' '}
+          <Link
+            href={`/${reverseOperation}/${reverseSlug}`}
+            className="text-indigo-300 underline underline-offset-2 hover:text-indigo-200"
+          >
+            Convert {reverseLabel} instead
+          </Link>
+          .
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Replace the input file's extension with the output extension. Falls back to
+ * `output.<ext>` if the input has no extension at all.
+ */
+function buildDownloadName(input: string, outputExt: string): string {
+  const dot = input.lastIndexOf('.');
+  const base = dot > 0 ? input.slice(0, dot) : input || 'output';
+  return `${base}.${outputExt}`;
+}

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -1,0 +1,294 @@
+'use client';
+
+// pSEO tool page composition. Spec §7.2 render order is fixed:
+//
+//   [H1: "MOV to MP4"]
+//   [One-line value prop]
+//   [Drop zone — works immediately, no scroll required]
+//   [Result area, hidden until job runs:
+//      - download button
+//      - "ffmpeg command:" code block, copy button
+//      - "Try another file" button
+//      - reverse-link
+//   ]
+//   [Three sibling links]
+//   [FAQ block]
+//   [Tiny "How it works" block]
+//   [Footer is in layout.tsx]
+//
+// This component is the proof-of-concept for the entire pSEO strategy. Phase 2
+// generates ≥200 pages by calling <ToolPage row={...} /> for every entry in
+// the operations matrix — so the API surface here MUST be just the row.
+
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+import { MATRIX_BY_SLUG } from '@/ops/matrix';
+import type { OperationRow } from '@/ops/types';
+import { type ConversionJob, DropZone } from './DropZone';
+import { FAQ } from './FAQ';
+import { ResultBlock } from './ResultBlock';
+
+export interface ToolPageProps {
+  row: OperationRow;
+}
+
+export function ToolPage({ row }: ToolPageProps) {
+  const [job, setJob] = useState<ConversionJob | null>(null);
+
+  const accept = useMemo(() => buildAcceptString(row), [row]);
+  const acceptLabel = useMemo(() => buildAcceptLabel(row), [row]);
+  const reverse = useMemo(() => findReverse(row), [row]);
+  const siblings = useMemo(() => resolveSiblings(row), [row]);
+  const extraArgs = useMemo(() => buildExtraArgs(row), [row]);
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 pt-12 pb-20 md:pt-16">
+      {/* Header — H1 + value prop */}
+      <header className="mb-8">
+        <h1 className="text-balance text-4xl font-bold tracking-tight text-gray-100 md:text-5xl">
+          {row.h1}
+        </h1>
+        <p className="mt-3 text-balance text-gray-400 text-lg">
+          {row.valueProp}
+        </p>
+      </header>
+
+      {/* Drop zone OR result block (one or the other) */}
+      <section className="mb-10" aria-label="Convert your file">
+        {!job ? (
+          <DropZone
+            goOp={row.goOp}
+            outputExt={extOf(row.outputFormat)}
+            accept={accept}
+            acceptLabel={acceptLabel}
+            extraArgs={extraArgs}
+            onJobComplete={setJob}
+          />
+        ) : (
+          <ResultBlock
+            job={job}
+            ffmpegCommand={row.ffmpegCommand}
+            reverseSlug={reverse?.slug}
+            reverseLabel={reverse?.label}
+            reverseOperation={reverse?.operation}
+            onReset={() => setJob(null)}
+          />
+        )}
+      </section>
+
+      {/* Three sibling links — internal-link block per spec §7.2 */}
+      {siblings.length > 0 && (
+        <section className="mb-12" aria-label="Related conversions">
+          <h2 className="mb-3 font-medium text-gray-300 text-sm uppercase tracking-wider">
+            Related
+          </h2>
+          <ul className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+            {siblings.map((s) => (
+              <li key={s.slug}>
+                <Link
+                  href={`/${s.operation}/${s.slug}`}
+                  className={[
+                    'flex h-full items-center justify-center rounded-xl',
+                    'border border-gray-800 bg-gray-900/40 px-4 py-3',
+                    'text-center font-medium text-gray-100 text-sm',
+                    'transition-colors hover:border-indigo-500 hover:bg-gray-900/60',
+                  ].join(' ')}
+                >
+                  {s.label}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* FAQ block */}
+      <section className="mb-12">
+        <FAQ faqs={row.faqs} />
+      </section>
+
+      {/* Tiny "How it works" block */}
+      <HowItWorks row={row} />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────── HOW IT WORKS ────────
+
+function HowItWorks({ row }: { row: OperationRow }) {
+  // Per spec §7.2 the "how it works" block is intentionally tiny — wasm vs
+  // server lane explanation + file deletion policy. Phase 6 will swap in the
+  // wasm copy on rows that run client-side; until then everything is server.
+  return (
+    <section aria-label="How it works">
+      <h2 className="mb-4 font-semibold text-gray-100 text-xl">How it works</h2>
+      <div className="space-y-3 text-gray-400 text-sm leading-relaxed">
+        <p>
+          Drop a file. We run{' '}
+          <code className="rounded bg-gray-900 px-1.5 py-0.5 text-gray-200">
+            ffmpeg
+          </code>{' '}
+          on our server, hand you back the result, and delete both files one
+          hour later.
+        </p>
+        <p>
+          The exact command we run is shown above with a copy button — paste it
+          into your own terminal if you prefer to keep the file on your machine.
+        </p>
+        <p className="text-gray-500 text-xs">
+          Backend operation:{' '}
+          <code className="rounded bg-gray-900 px-1.5 py-0.5 text-gray-300">
+            {row.goOp}
+          </code>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}
+
+// ─────────────────────────────────────────────────────── HELPERS ─────────────
+
+/**
+ * Map a Format enum to the file extension used in URLs and filenames. Most
+ * formats are their own extension; the special-cases below cover the ones
+ * with longer names.
+ */
+function extOf(format: string): string {
+  switch (format) {
+    case 'gif-static':
+      return 'gif';
+    case 'webp-anim':
+      return 'webp';
+    default:
+      return format;
+  }
+}
+
+/**
+ * Build the `<input accept>` attribute from the row's accepted input formats.
+ * Each format maps to its `.ext` form; we don't bother with MIME types since
+ * the backend validates anyway.
+ */
+function buildAcceptString(row: OperationRow): string {
+  return row.inputFormats.map((f) => `.${extOf(f)}`).join(',');
+}
+
+/**
+ * Human-readable accept label for the drop zone copy. Single format → just
+ * the name (`MOV`); 2-3 formats → all listed; many formats → "video file" etc.
+ */
+function buildAcceptLabel(row: OperationRow): string {
+  if (row.inputFormats.length === 0) return 'file';
+  if (row.inputFormats.length === 1) {
+    return extOf(row.inputFormats[0] ?? '').toUpperCase();
+  }
+  if (row.inputFormats.length <= 3) {
+    return row.inputFormats.map((f) => extOf(f).toUpperCase()).join(', ');
+  }
+  // Many inputs — group by media kind for the copy.
+  return 'video file';
+}
+
+/**
+ * Build the `extraArgs` map forwarded to the Go op. Pulls preset hints from
+ * the row (CRF, target size, FPS, etc.) — the backend reads them from the
+ * multipart form values.
+ */
+function buildExtraArgs(row: OperationRow): Record<string, string> | undefined {
+  const args: Record<string, string> = {};
+  const p = row.preset;
+  if (!p) return undefined;
+  if (p.crf !== undefined) args.crf = String(p.crf);
+  if (p.preset !== undefined) args.preset = p.preset;
+  if (p.targetSizeMb !== undefined) {
+    args.target_size_mb = String(p.targetSizeMb);
+  }
+  if (p.resolution !== undefined) args.resolution = p.resolution;
+  if (p.fps !== undefined) args.fps = String(p.fps);
+  if (p.audioBitrate !== undefined) args.audio_bitrate = p.audioBitrate;
+  return Object.keys(args).length > 0 ? args : undefined;
+}
+
+interface SiblingLink {
+  slug: string;
+  label: string;
+  operation: string;
+}
+
+/**
+ * Resolve `row.related` slugs against the matrix. Falls back to a plain label
+ * derived from the slug when a sibling row isn't in the matrix yet (Phase 2
+ * will add the long-tail rows).
+ */
+function resolveSiblings(row: OperationRow): SiblingLink[] {
+  return (row.related ?? []).map((slug) => {
+    const sib = MATRIX_BY_SLUG[slug];
+    if (sib) {
+      return { slug, label: sib.h1, operation: sib.operation };
+    }
+    // Sibling row doesn't exist yet — synthesise a label from the slug.
+    return {
+      slug,
+      label: humanise(slug),
+      operation: inferOperationFromSlug(slug),
+    };
+  });
+}
+
+/**
+ * Find the inverse-direction row (e.g. `mov-to-mp4` → `mp4-to-mov`). Only
+ * applies to two-format `convert` rows. Returns null when there's no clean
+ * reverse (e.g. `extract-audio`, multi-input `video-to-mp4`).
+ */
+function findReverse(
+  row: OperationRow,
+): { slug: string; label: string; operation: string } | null {
+  if (row.operation !== 'convert') return null;
+  if (row.inputFormats.length !== 1) return null;
+  const inputExt = extOf(row.inputFormats[0] ?? '');
+  const outputExt = extOf(row.outputFormat);
+  const reverseSlug = `${outputExt}-to-${inputExt}`;
+  const sib = MATRIX_BY_SLUG[reverseSlug];
+  if (!sib) return null;
+  return {
+    slug: sib.slug,
+    label: sib.h1,
+    operation: sib.operation,
+  };
+}
+
+/** Convert a slug like `mp4-to-webm` to a plain label `MP4 → WebM`. */
+function humanise(slug: string): string {
+  return slug
+    .replace('-to-', ' → ')
+    .replace(/-/g, ' ')
+    .replace(/\b([a-z])/g, (m) => m.toUpperCase())
+    .replace(
+      /Mp4|Mov|Webm|Mkv|Mpeg|Mp3|Wav|Aac|Flac|Webp|Heic|Avif|Jpg|Png|Gif/gi,
+      (m) => m.toUpperCase(),
+    );
+}
+
+/**
+ * Infer the operation prefix (URL segment) from a slug. Used when a sibling
+ * row isn't in the matrix yet — we still need to render a working link.
+ */
+function inferOperationFromSlug(slug: string): string {
+  if (slug.startsWith('compress-')) return 'compress';
+  if (slug.startsWith('trim-')) return 'trim';
+  if (slug.startsWith('resize-')) return 'resize';
+  if (slug.startsWith('thumbnail-')) return 'thumbnail';
+  if (slug.startsWith('contact-sheet-')) return 'contact-sheet';
+  if (slug.startsWith('image-')) return 'convert';
+  if (
+    slug.endsWith('-to-mp3') ||
+    slug.endsWith('-to-wav') ||
+    slug.endsWith('-to-aac') ||
+    slug.endsWith('-to-flac')
+  ) {
+    return slug.startsWith('video-') ? 'extract-audio' : 'convert';
+  }
+  if (slug.endsWith('-to-gif')) return 'gif';
+  return 'convert';
+}


### PR DESCRIPTION
Closes #39

## Summary
- Builds the reusable `<ToolPage row={...} />` component composing H1, value prop, drop zone, result block (download + ffmpeg command + copy + reverse link), three sibling links, FAQ (with FAQPage JSON-LD), and "How it works" — per spec §7.2.
- Splits supporting components into `DropZone` (generic upload-and-convert), `ResultBlock` (post-conversion display), and `FAQ` (collapsible + schema.org).
- Adds `/convert/[slug]/page.tsx` that looks up the matrix row and statically generates every `convert` row at build time. `/convert/mov-to-mp4` is the proof-of-concept hero page.

## Test plan
- [x] `yarn workspace ffmpeg-converter-next build` passes; `/convert/mov-to-mp4` appears in the SSG output
- [x] `tsc --noEmit` is clean for the workspace
- [x] `/convert/mov-to-mp4` renders H1, value prop, drop zone, related-links block, FAQ, and "How it works"
- [x] `<title>`, `<h1>`, and `application/ld+json` FAQPage schema all present
- [x] Drop a `.mov` → upload via `/api/convert` proxy → Go backend on :9876 → downloadable `.mp4` (verified via curl through proxy)
- [x] `<ToolPage row={...} />` API surface accepts any `OperationRow`, ready for Phase 2 to call 200+ times