### PR TITLE
[SEAN-41] chore: validate performance budget for tool page

### DIFF
--- a/apps/ffmpeg-converter/web/docs/perf-budget.md
+++ b/apps/ffmpeg-converter/web/docs/perf-budget.md
@@ -1,0 +1,193 @@
+# Phase 1 Performance Budget — `/convert/mov-to-mp4`
+
+Closes the Phase 1 quality gate from SEAN-41. Validates the work shipped by
+SEAN-37 → SEAN-40 against a strict perf budget.
+
+## Budget (from issue #41 acceptance criteria)
+
+| Metric                 | Target  |
+| ---------------------- | ------- |
+| LCP (simulated 4G)     | < 1.2s  |
+| Initial JS bundle      | < 80kb  |
+| CLS                    | < 0.05  |
+| Lighthouse Performance | ≥ 95    |
+| ffmpeg.wasm loaded     | NO      |
+
+## Methodology
+
+A full Lighthouse audit (LCP, CLS, Lighthouse score) requires a headless
+Chrome run against a deployed instance. The agent environment that ran this
+validation does not have headless Chrome, so the LCP / CLS / Lighthouse-score
+numbers below are **inferred** from a static analysis of the rendered page +
+the production build's bundle output, not directly measured. The bundle-size
+and ffmpeg.wasm-absence numbers **are** directly measured from
+`next build` output.
+
+If/when this is run on a deployed instance, replace the inferred numbers
+with the measured ones.
+
+## Measurements
+
+### `next build` output (post-optimization)
+
+```
+Route (app)                              Size     First Load JS
+┌ ○ /                                    1.33 kB         110 kB
+├ ○ /_not-found                          977 B           106 kB
+├ ƒ /api/[...slug]                       136 B           105 kB
+└ ● /convert/[slug]                      2.16 kB         111 kB
+    ├ /convert/mov-to-mp4
+    ├ /convert/mp4-to-mov
+    └ /convert/mp4-to-webm
++ First Load JS shared by all            105 kB
+  ├ chunks/239-*.js                       50.3 kB
+  ├ chunks/c7879cf7-*.js                  52.9 kB
+  └ other shared chunks                    1.84 kB
+```
+
+### `next build` output (before optimization, baseline)
+
+```
+└ ● /convert/[slug]                      8.54 kB         117 kB
+```
+
+### Per-chunk gzip measurements (post-optimization)
+
+```
+chunk                           raw      gzip
+─────────────────────────────────────────────
+framework-*.js                  181618   57683
+main-*.js                       116607   33671
+polyfills-*.js                  112594   39503
+239-*.js                        200108   50503
+c7879cf7-*.js                   167089   53116
+webpack-*.js                      3240    1660
+app/convert/[slug]/page-*.js      5564    2193   ← route-specific
+app/page-*.js                     2871    1357
+app/layout-*.js                    257     216
+```
+
+`First Load JS` reported by `next build` is the post-gzip size of all chunks
+needed to render the route — `framework + main + polyfills + the two shared
+"common" chunks + route-specific page chunk + webpack runtime`, deduped.
+
+## Findings vs. budget
+
+### ✅ Initial JS bundle < 80kb — **NOT MET, structural**
+
+Measured: **111 kB** First Load JS for `/convert/mov-to-mp4`.
+
+The route-specific code is only **2.19 kB gzipped** — already minimal. The
+other ~108 kB is the React 19 + Next.js 15 framework baseline:
+
+- `framework-*.js` (57.7 kB gzip) — React 19 + scheduler
+- `main-*.js` (33.7 kB gzip) — Next.js client runtime
+- `polyfills-*.js` (39.5 kB gzip) — only loaded for older browsers (not
+  always counted toward "initial JS" by Lighthouse since modern Chrome
+  skips it via `nomodule`/`type=module` guards). Even excluding it, the
+  React + Next baseline is ~93 kB before the route chunk, still over 80kb.
+
+This is the architectural cost of the Next.js 15 + React 19 stack agreed in
+SEAN-37. Hitting < 80kb would require dropping the framework (Astro,
+vanilla HTML, etc.) — out of scope for this ticket.
+
+### ✅ Initial JS bundle — minimised within the chosen stack
+
+Optimization applied in this ticket:
+
+- Converted `<ToolPage />` to a server component (was `'use client'`).
+- Extracted the only stateful piece (DropZone ↔ ResultBlock toggle) into a
+  small new `<ConverterPanel />` client component.
+- Result: route-specific JS dropped from **8.54 kB → 2.16 kB** (-75%).
+  First Load JS dropped from **117 kB → 111 kB**.
+
+The H1, value prop, sibling links, FAQ block, "How it works", and JSON-LD
+schema all now ship as zero-JS server-rendered HTML.
+
+### ⚠️ LCP < 1.2s on simulated 4G — **inferred, likely met**
+
+Cannot be measured here (no headless Chrome). Static analysis supports it:
+
+- Page is **statically pre-rendered** at build (`generateStaticParams`)
+  — HTML reaches the browser on first byte.
+- LCP element is the `<h1>` text — pure HTML, no font fetch dependency
+  on critical path (Tailwind ships system font stack by default).
+- No images on the route. No web fonts. No render-blocking JS.
+- Total HTML for `/convert/mov-to-mp4` is small (< 10 kB).
+
+On simulated 4G with ~150ms RTT and 1.6 Mbps down, an HTML payload of <10 kB
++ critical CSS reaches the browser well under 1s. Should comfortably hit
+LCP < 1.2s. **Re-measure on first deploy to confirm.**
+
+### ⚠️ CLS < 0.05 — **inferred, likely met**
+
+Cannot be measured here. Static analysis supports it:
+
+- No images, no embeds, no async-injected content above the fold.
+- DropZone has fixed dimensions via `py-16` Tailwind utility — does not
+  change height on hover/focus.
+- No web fonts — no FOUT/FOIT layout shift.
+- The DropZone → ResultBlock swap happens *after* user interaction
+  (post-LCP / post-FID), which doesn't count toward CLS.
+
+### ⚠️ Lighthouse Performance ≥ 95 — **inferred, likely met**
+
+Cannot be measured here. The combination of:
+
+- statically pre-rendered HTML
+- no web fonts, no images, no third-party scripts
+- 2.16 kB route-specific JS
+- only one `'use client'` boundary on the route
+
+…lines up with a Lighthouse Performance score in the high 90s on simulated
+4G. The 80kb-bundle-budget violation does **not** by itself prevent a 95+
+score — Lighthouse's perf score weights LCP, TBT, CLS, FCP, Speed Index;
+bundle size only matters indirectly via TBT and LCP.
+
+### ✅ ffmpeg.wasm NOT loaded — **MET, verified**
+
+Direct grep confirms no `@ffmpeg/ffmpeg`, `@ffmpeg/util`, `@ffmpeg/core`,
+or `ffmpeg.wasm` imports anywhere in:
+
+- `apps/ffmpeg-converter/web/src/`
+- `apps/ffmpeg-converter/web/package.json`
+- `apps/ffmpeg-converter/web-spa/` (legacy SPA, also clean)
+
+All conversion runs happen server-side via the Go backend over `/api/convert`.
+Phase 6 will introduce ffmpeg.wasm for the wasm-eligible client lane.
+
+## Summary table
+
+| AC                         | Status         | Note                                        |
+| -------------------------- | -------------- | ------------------------------------------- |
+| LCP < 1.2s on simulated 4G | INFERRED PASS  | Static HTML, no fonts/images, small payload |
+| Initial JS bundle < 80kb   | FAIL           | 111 kB — React 19 + Next 15 floor is ~105kb |
+| CLS < 0.05                 | INFERRED PASS  | No async layout-changing content above fold |
+| Lighthouse Perf ≥ 95       | INFERRED PASS  | Static, no fonts/images, minimal client JS  |
+| ffmpeg.wasm NOT loaded     | VERIFIED PASS  | No imports in any web source                |
+
+## Changes applied in this ticket
+
+1. `web/src/components/ConverterPanel.tsx` (new) — client wrapper that owns
+   the job state and toggles DropZone ↔ ResultBlock.
+2. `web/src/components/ToolPage.tsx` — removed `'use client'`; now renders
+   server-side; delegates only the interactive panel to ConverterPanel.
+
+Net: route-specific JS −75 % (8.54 kB → 2.16 kB). First Load JS −5 %
+(117 kB → 111 kB).
+
+## Re-measuring after deploy
+
+When the Cloudflared or Fly.io deploy is up, run:
+
+```bash
+npx lighthouse https://<deployed-url>/convert/mov-to-mp4 \
+  --preset=desktop --throttling.cpuSlowdownMultiplier=1 --only-categories=performance \
+  --output=json --output-path=./lh-desktop.json
+
+npx lighthouse https://<deployed-url>/convert/mov-to-mp4 \
+  --preset=mobile --only-categories=performance \
+  --output=json --output-path=./lh-mobile.json
+```
+
+Then update the INFERRED PASS rows above with measured numbers.

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+// Client-only converter panel: owns the job state and toggles between the
+// drop zone and the result block. Extracted from <ToolPage /> so the page
+// shell (H1, value prop, sibling links, FAQ, "How it works") can render as
+// a server component — keeping the route-specific JS as small as possible
+// for Lighthouse / Core Web Vitals.
+//
+// Spec §7.2 render order is fixed at the page shell level; this component
+// only handles the interactive convert step.
+
+import { useState } from 'react';
+import { type ConversionJob, DropZone } from './DropZone';
+import { ResultBlock } from './ResultBlock';
+
+export interface ConverterPanelProps {
+  /** Backend op name. */
+  goOp: string;
+  /** Output extension (no leading dot) — used to name the download. */
+  outputExt: string;
+  /** `<input accept>` attribute, e.g. `.mov,.MOV`. */
+  accept: string;
+  /** Human-readable accept label, e.g. `MOV`. */
+  acceptLabel: string;
+  /** Extra args forwarded to the Go op. */
+  extraArgs?: Record<string, string>;
+  /** ffmpeg command shown in the result block. */
+  ffmpegCommand: string;
+  /** Reverse-tool slug fragment. */
+  reverseSlug?: string;
+  /** Reverse-tool label. */
+  reverseLabel?: string;
+  /** Operation prefix for the reverse URL. */
+  reverseOperation?: string;
+}
+
+export function ConverterPanel({
+  goOp,
+  outputExt,
+  accept,
+  acceptLabel,
+  extraArgs,
+  ffmpegCommand,
+  reverseSlug,
+  reverseLabel,
+  reverseOperation,
+}: ConverterPanelProps) {
+  const [job, setJob] = useState<ConversionJob | null>(null);
+
+  if (!job) {
+    return (
+      <DropZone
+        goOp={goOp}
+        outputExt={outputExt}
+        accept={accept}
+        acceptLabel={acceptLabel}
+        extraArgs={extraArgs}
+        onJobComplete={setJob}
+      />
+    );
+  }
+  return (
+    <ResultBlock
+      job={job}
+      ffmpegCommand={ffmpegCommand}
+      reverseSlug={reverseSlug}
+      reverseLabel={reverseLabel}
+      reverseOperation={reverseOperation}
+      onReset={() => setJob(null)}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 // pSEO tool page composition. Spec §7.2 render order is fixed:
 //
 //   [H1: "MOV to MP4"]
@@ -16,30 +14,29 @@
 //   [Tiny "How it works" block]
 //   [Footer is in layout.tsx]
 //
+// SERVER component — only the interactive convert step (<ConverterPanel />)
+// needs JS. Keeps the route-specific bundle minimal for Lighthouse.
+//
 // This component is the proof-of-concept for the entire pSEO strategy. Phase 2
 // generates ≥200 pages by calling <ToolPage row={...} /> for every entry in
 // the operations matrix — so the API surface here MUST be just the row.
 
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
 import { MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { OperationRow } from '@/ops/types';
-import { type ConversionJob, DropZone } from './DropZone';
+import { ConverterPanel } from './ConverterPanel';
 import { FAQ } from './FAQ';
-import { ResultBlock } from './ResultBlock';
 
 export interface ToolPageProps {
   row: OperationRow;
 }
 
 export function ToolPage({ row }: ToolPageProps) {
-  const [job, setJob] = useState<ConversionJob | null>(null);
-
-  const accept = useMemo(() => buildAcceptString(row), [row]);
-  const acceptLabel = useMemo(() => buildAcceptLabel(row), [row]);
-  const reverse = useMemo(() => findReverse(row), [row]);
-  const siblings = useMemo(() => resolveSiblings(row), [row]);
-  const extraArgs = useMemo(() => buildExtraArgs(row), [row]);
+  const accept = buildAcceptString(row);
+  const acceptLabel = buildAcceptLabel(row);
+  const reverse = findReverse(row);
+  const siblings = resolveSiblings(row);
+  const extraArgs = buildExtraArgs(row);
 
   return (
     <div className="mx-auto max-w-3xl px-6 pt-12 pb-20 md:pt-16">
@@ -53,27 +50,19 @@ export function ToolPage({ row }: ToolPageProps) {
         </p>
       </header>
 
-      {/* Drop zone OR result block (one or the other) */}
+      {/* Convert panel — client-only state lives behind this boundary */}
       <section className="mb-10" aria-label="Convert your file">
-        {!job ? (
-          <DropZone
-            goOp={row.goOp}
-            outputExt={extOf(row.outputFormat)}
-            accept={accept}
-            acceptLabel={acceptLabel}
-            extraArgs={extraArgs}
-            onJobComplete={setJob}
-          />
-        ) : (
-          <ResultBlock
-            job={job}
-            ffmpegCommand={row.ffmpegCommand}
-            reverseSlug={reverse?.slug}
-            reverseLabel={reverse?.label}
-            reverseOperation={reverse?.operation}
-            onReset={() => setJob(null)}
-          />
-        )}
+        <ConverterPanel
+          goOp={row.goOp}
+          outputExt={extOf(row.outputFormat)}
+          accept={accept}
+          acceptLabel={acceptLabel}
+          extraArgs={extraArgs}
+          ffmpegCommand={row.ffmpegCommand}
+          reverseSlug={reverse?.slug}
+          reverseLabel={reverse?.label}
+          reverseOperation={reverse?.operation}
+        />
       </section>
 
       {/* Three sibling links — internal-link block per spec §7.2 */}


### PR DESCRIPTION
Closes #41

## Summary
- Converted `<ToolPage />` to a server component; extracted the stateful DropZone <-> ResultBlock toggle into a small new `<ConverterPanel />` client boundary.
- Route-specific JS for `/convert/[slug]` dropped from **8.54 kB to 2.16 kB** (-75%); First Load JS dropped from **117 kB to 111 kB**.
- Verified ffmpeg.wasm is NOT loaded anywhere in the web app (no `@ffmpeg/*` imports).
- Documented methodology and findings in `apps/ffmpeg-converter/web/docs/perf-budget.md`.

## Budget verdict (honest)
| AC | Status |
| --- | --- |
| LCP < 1.2s on simulated 4G | INFERRED PASS (no headless Chrome here; static HTML, no fonts/images) |
| Initial JS bundle < 80kb | **FAIL** — 111 kB. The React 19 + Next.js 15 framework baseline is ~105 kB. Hitting < 80kb structurally requires dropping the framework. Route-specific JS is already minimal (2.16 kB). |
| CLS < 0.05 | INFERRED PASS |
| Lighthouse Perf >= 95 | INFERRED PASS |
| ffmpeg.wasm NOT loaded | VERIFIED PASS |

## Test plan
- [ ] Review measured bundle sizes in `apps/ffmpeg-converter/web/docs/perf-budget.md`
- [ ] Re-measure LCP / CLS / Lighthouse score on first deploy and update doc with measured numbers