### PR TITLE
[SEAN-53] feat: robots.txt with AI-bot allowlist

### DIFF
--- a/apps/ffmpeg-converter/web/public/robots.txt
+++ b/apps/ffmpeg-converter/web/public/robots.txt
@@ -1,0 +1,40 @@
+# robots.txt for seansconverter.com
+# We want to be crawled and indexed — by both traditional search engines
+# and AI/LLM crawlers (positive AEO signal).
+# /api/ is REST plumbing, not for indexing.
+
+User-agent: *
+Allow: /
+Disallow: /api/
+
+User-agent: Googlebot
+Allow: /
+Disallow: /api/
+
+User-agent: Bingbot
+Allow: /
+Disallow: /api/
+
+User-agent: GPTBot
+Allow: /
+Disallow: /api/
+
+User-agent: ClaudeBot
+Allow: /
+Disallow: /api/
+
+User-agent: anthropic-ai
+Allow: /
+Disallow: /api/
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /api/
+
+User-agent: Google-Extended
+Allow: /
+Disallow: /api/
+
+User-agent: CCBot
+Allow: /
+Disallow: /api/


### PR DESCRIPTION
Closes #53

## Summary
- Add `apps/ffmpeg-converter/web/public/robots.txt` with `User-agent: *` plus explicit named blocks for `Googlebot`, `Bingbot`, `GPTBot`, `ClaudeBot`, `anthropic-ai`, `PerplexityBot`, `Google-Extended`, `CCBot` — all `Allow: /` with `Disallow: /api/`.
- No `Sitemap:` directive yet — that lands with the sitemap ticket once `sitemap.xml` exists (otherwise crawlers would 404 the listed URLs).
- Next.js serves files in `public/` at the site root, so this is reachable at `/robots.txt` from `next dev` and prod with no extra wiring.

## Test plan
- [ ] From `apps/ffmpeg-converter/web`: `yarn dev` then `curl -s http://localhost:3000/robots.txt` returns the file with all 9 user-agent blocks.
- [ ] Confirm there is no `Sitemap:` line yet.
- [ ] Confirm `Disallow: /api/` appears under every block.