### PR TITLE
[SEAN-52] feat: dynamic operation routes for Phase 2

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/compress/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/compress/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `compress` rows.
+//
+// Renders one static page per matrix row whose `operation === 'compress'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'compress' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function CompressPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `contact-sheet` rows.
+//
+// Renders one static page per matrix row whose `operation === 'contact-sheet'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'contact-sheet' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function ContactSheetPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/convert/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/convert/[slug]/page.tsx
@@ -1,11 +1,19 @@
-// pSEO tool page route. Phase 1 only renders rows whose `operation === 'convert'`
-// — Phase 2 ships /compress/[slug], /extract-audio/[slug], /gif/[slug] etc.
-// using the same <ToolPage row=... /> component.
+// pSEO tool page route. Phase 2 ships /compress/[slug], /extract-audio/[slug],
+// /gif/[slug], /trim/[slug], /resize/[slug], /thumbnail/[slug],
+// /contact-sheet/[slug] and /normalize-audio/[slug] alongside this one.
+//
+// `/convert/[slug]` accepts BOTH `operation === 'convert'` AND
+// `operation === 'image-convert'` rows. Per Directive 1's verb-first slug rule,
+// image-convert pages live under `/convert/...` (`image-to-webp`,
+// `image-to-jpg` etc.) — the user-facing verb is still "convert" and the
+// `/image/...` segment stays free for future image-only operations
+// (compress-image, resize-image) that will own that segment.
 //
 // Dynamic param resolution:
 //   - slug is looked up against MATRIX_BY_SLUG.
-//   - If the slug is unknown OR points at a non-convert row, return notFound().
-//   - generateStaticParams pre-renders every convert row at build time so the
+//   - If the slug is unknown OR its row.operation isn't convert/image-convert,
+//     return notFound().
+//   - generateStaticParams pre-renders every matching row at build time so the
 //     pages ship as static HTML (Lighthouse Performance ≥95 budget).
 //   - generateMetadata pulls the row's `title` for the <title> + meta tags.
 
@@ -14,9 +22,16 @@ import { notFound } from 'next/navigation';
 import { ToolPage } from '@/components/ToolPage';
 import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
 
-// Static generation — list every convert-row slug.
+const ACCEPTED_OPERATIONS = ['convert', 'image-convert'] as const;
+type AcceptedOperation = (typeof ACCEPTED_OPERATIONS)[number];
+
+function isAccepted(op: string): op is AcceptedOperation {
+  return (ACCEPTED_OPERATIONS as readonly string[]).includes(op);
+}
+
+// Static generation — list every convert/image-convert row slug.
 export function generateStaticParams() {
-  return MATRIX.filter((row) => row.operation === 'convert').map((row) => ({
+  return MATRIX.filter((row) => isAccepted(row.operation)).map((row) => ({
     slug: row.slug,
   }));
 }
@@ -30,7 +45,7 @@ export async function generateMetadata({
 }: RouteParams): Promise<Metadata> {
   const { slug } = await params;
   const row = MATRIX_BY_SLUG[slug];
-  if (!row || row.operation !== 'convert') {
+  if (!row || !isAccepted(row.operation)) {
     return { title: 'Not found' };
   }
   return {
@@ -42,7 +57,7 @@ export async function generateMetadata({
 export default async function ConvertPage({ params }: RouteParams) {
   const { slug } = await params;
   const row = MATRIX_BY_SLUG[slug];
-  if (!row || row.operation !== 'convert') {
+  if (!row || !isAccepted(row.operation)) {
     notFound();
   }
   return <ToolPage row={row} />;

--- a/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `extract-audio` rows.
+//
+// Renders one static page per matrix row whose `operation === 'extract-audio'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'extract-audio' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function ExtractAudioPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/gif/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/gif/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `gif` rows.
+//
+// Renders one static page per matrix row whose `operation === 'gif'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'gif' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function GifPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `normalize-audio` rows.
+//
+// Renders one static page per matrix row whose `operation === 'normalize-audio'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'normalize-audio' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function NormalizeAudioPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/resize/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/resize/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `resize` rows.
+//
+// Renders one static page per matrix row whose `operation === 'resize'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'resize' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function ResizePage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `thumbnail` rows.
+//
+// Renders one static page per matrix row whose `operation === 'thumbnail'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'thumbnail' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function ThumbnailPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}

--- a/apps/ffmpeg-converter/web/src/app/trim/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/trim/[slug]/page.tsx
@@ -1,0 +1,47 @@
+// pSEO tool page route for `trim` rows.
+//
+// Renders one static page per matrix row whose `operation === 'trim'`.
+// All rendering goes through the shared <ToolPage row={...} /> component —
+// no per-operation customisation lives here.
+//
+// See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
+
+import type { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { ToolPage } from '@/components/ToolPage';
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+
+const OPERATION = 'trim' as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === OPERATION).map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface RouteParams {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateMetadata({
+  params,
+}: RouteParams): Promise<Metadata> {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    return { title: 'Not found' };
+  }
+  return {
+    title: row.title,
+    description: row.valueProp,
+  };
+}
+
+export default async function TrimPage({ params }: RouteParams) {
+  const { slug } = await params;
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || row.operation !== OPERATION) {
+    notFound();
+  }
+  return <ToolPage row={row} />;
+}


### PR DESCRIPTION
Closes #52

## Summary
- Adds `app/{operation}/[slug]/page.tsx` for the eight remaining Phase 2 ops: `compress`, `extract-audio`, `gif`, `trim`, `resize`, `thumbnail`, `contact-sheet`, `normalize-audio`. Each route filters `generateStaticParams` to its own operation and renders via the shared `<ToolPage row={row} />` component — no per-operation customisation.
- Updates `/convert/[slug]/page.tsx` to also accept `operation === 'image-convert'` rows so `image-to-webp` and `image-to-jpg` resolve under `/convert/...` per Directive 1's verb-first slug rule (collapses `image-convert` into `/convert/...` and leaves the `/image/...` segment free for future image-only ops).
- `next build` succeeds with 18 pSEO pages prerendered as static HTML; First Load JS unchanged at ~111 kB across new routes.

## Test plan
- [x] `yarn build` (Next.js) succeeds — 26 routes, 18 SSG pages
- [x] `npx tsc --noEmit` passes for `apps/ffmpeg-converter/web`
- [x] `yarn biome check apps/ffmpeg-converter/web/src/app/` passes
- [ ] Spot-check Lighthouse on at least one new route per operation (run after deploy)
- [ ] Confirm flagship pills + tool-page sibling links no longer 404 once SEAN-50 lands and points hrefs at matrix-derived slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)