### PR TITLE
[SEAN-51] fix: dead header/footer links to /pricing /docs /llms.txt

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/docs/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/docs/page.tsx
@@ -1,0 +1,36 @@
+// Phase 4/5 placeholder. The real /docs surface — /docs/api (Phase 4) and
+// /docs/mcp (Phase 5) — ships with the API tier and MCP server. This stub
+// exists so the header & footer Docs link doesn't 404 in the meantime.
+// Do NOT remove the route without also removing the nav links — see SEAN-51.
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: "Docs — Sean's Converter",
+  description:
+    "Developer docs for Sean's Converter — coming with the public API tier in Phase 4 and MCP server in Phase 5.",
+};
+
+export default function DocsPage() {
+  return (
+    <section className="mx-auto max-w-3xl px-6 pt-16 pb-20 text-center">
+      <h1 className="text-balance text-4xl font-bold tracking-tight text-gray-100 md:text-5xl">
+        Docs
+      </h1>
+      <p className="mt-6 text-balance text-lg text-gray-400">
+        The API reference and MCP server install guide are coming with the API
+        tier in Phase 4. Until then, every tool page shows the exact ffmpeg
+        command for the job — start there.
+      </p>
+      <p className="mt-10">
+        <Link
+          href="/"
+          className="text-sm text-gray-300 underline underline-offset-4 hover:text-white"
+        >
+          Back to home
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/layout.tsx
+++ b/apps/ffmpeg-converter/web/src/app/layout.tsx
@@ -25,6 +25,9 @@ export default function RootLayout({
             >
               Sean&apos;s Converter
             </Link>
+            {/* /pricing and /docs are placeholder routes until Phase 4 ships
+                the real pages — see SEAN-51. Do not add a nav link here
+                without first creating its route. */}
             <nav aria-label="Primary">
               <ul className="flex items-center gap-5 text-sm text-gray-400">
                 <li>

--- a/apps/ffmpeg-converter/web/src/app/llms.txt/route.ts
+++ b/apps/ffmpeg-converter/web/src/app/llms.txt/route.ts
@@ -1,0 +1,29 @@
+// Phase 5 placeholder. The real /llms.txt — generated from the operations
+// matrix per spec §10 — ships alongside the MCP server in Phase 5. This stub
+// is a valid llms.txt body so the footer link doesn't 404 in the meantime.
+// Do NOT remove this route without also removing the footer link — see SEAN-51.
+
+export const dynamic = 'force-static';
+
+const BODY = `# Sean's Converter
+
+> Free, in-browser file converter for video, audio, and images. No watermark,
+> no signup, no email gate. Every job shows the equivalent ffmpeg command.
+
+This llms.txt is a Phase 5 placeholder. The full machine-readable index of
+every tool page and recipe lives at /llms-full.txt once Phase 5 ships.
+
+## Links
+
+- [Homepage](https://seansconverter.com/)
+- [Source](https://github.com/seanmizen/seanorepo)
+`;
+
+export function GET() {
+  return new Response(BODY, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'public, max-age=3600',
+    },
+  });
+}

--- a/apps/ffmpeg-converter/web/src/app/pricing/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/pricing/page.tsx
@@ -1,0 +1,36 @@
+// Phase 4 placeholder. The real /pricing page (three columns: Free / Pro £10/mo
+// / API metered, per phased-spec.md §"Phase 4") ships with the API tier. This
+// stub exists so the header & footer Pricing link doesn't 404 in the meantime.
+// Do NOT remove the route without also removing the nav links — see SEAN-51.
+
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: "Pricing — Sean's Converter",
+  description:
+    "Pricing for Sean's Converter — coming with the public API tier in Phase 4.",
+};
+
+export default function PricingPage() {
+  return (
+    <section className="mx-auto max-w-3xl px-6 pt-16 pb-20 text-center">
+      <h1 className="text-balance text-4xl font-bold tracking-tight text-gray-100 md:text-5xl">
+        Pricing
+      </h1>
+      <p className="mt-6 text-balance text-lg text-gray-400">
+        The browser converter is — and stays — free. A Pro tier and a metered
+        public API are coming with Phase 4. Until then, drop a file on the
+        homepage and convert away.
+      </p>
+      <p className="mt-10">
+        <Link
+          href="/"
+          className="text-sm text-gray-300 underline underline-offset-4 hover:text-white"
+        >
+          Back to home
+        </Link>
+      </p>
+    </section>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
+++ b/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
@@ -1,5 +1,6 @@
-// Site footer. Per spec §7.1: link to /llms.txt (file ships in Phase 5 — the
-// link is a placeholder for now, signalling AEO confidence).
+// Site footer. Every link here MUST resolve — /pricing, /docs, /llms.txt all
+// have placeholder routes until Phase 4/5 ship the real pages (see SEAN-51).
+// Do not add a nav link here without first creating its route.
 
 import Link from 'next/link';
 
@@ -14,8 +15,6 @@ export function SiteFooter() {
               <Link
                 href="/llms.txt"
                 className="hover:text-gray-300"
-                // /llms.txt is a Phase 5 deliverable — the route doesn't exist
-                // yet. We still render the link so the IA is set in stone.
                 prefetch={false}
               >
                 /llms.txt


### PR DESCRIPTION
Closes #51

## Summary
- Add minimal placeholder pages at `/pricing` and `/docs` (Phase 4 deliverable) — single paragraph + back-to-home link, dark-themed to match the rest of the site
- Add `/llms.txt` route handler returning a small valid llms.txt body so the footer link resolves until the real Phase 5 generated version ships
- Refresh comments in `layout.tsx` and `SiteFooter.tsx` to flag the placeholder routes and warn the next agent against re-introducing dead links

## Test plan
- [ ] `yarn workspace @seans/ffmpeg-converter-web start` and click Pricing, Docs, and `/llms.txt` from the header/footer — none should 404
- [ ] `/llms.txt` returns `text/plain; charset=utf-8` with the placeholder body
- [ ] Biome (`biome check`) and `tsc --noEmit` both pass on the touched files