### PR TITLE
[SEAN-50] fix: gate dead nav links on matrix presence

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -7,7 +7,9 @@
     "start": "next dev --port 4050",
     "build": "next build",
     "serve": "next start --port 4050",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:dead-links": "ts-node -P tsconfig.test.json src/components/__tests__/dead-links.test.ts",
+    "test": "yarn test:dead-links"
   },
   "dependencies": {
     "next": "15.1.6",
@@ -21,6 +23,8 @@
     "autoprefixer": "^10.4.20",
     "postcss": "^8.5.1",
     "tailwindcss": "^3.4.17",
+    "ts-node": "^10.9.2",
+    "tsconfig-paths": "^3.15.0",
     "typescript": "^5.9.3"
   }
 }

--- a/apps/ffmpeg-converter/web/src/components/FlagshipPills.tsx
+++ b/apps/ffmpeg-converter/web/src/components/FlagshipPills.tsx
@@ -1,11 +1,17 @@
 // 12-flagship pill row from STRATEGY.md. Two rows of six on desktop, wraps
 // on smaller breakpoints. Each pill is an anchor to the canonical tool page
 // — pure server component, no client JS.
+//
+// SEAN-50: pills are derived from the matrix and gated on route presence, so
+// the rendered list shrinks/grows automatically as new routes ship. If the
+// list is empty (shouldn't happen in practice — Phase 1 ships at least the
+// flagship convert pages) we render nothing rather than a dangling header.
 
 import Link from 'next/link';
 import { FLAGSHIP_PRESETS } from './flagship-data';
 
 export function FlagshipPills() {
+  if (FLAGSHIP_PRESETS.length === 0) return null;
   return (
     <nav aria-label="Popular conversions" className="w-full">
       <h2 className="mb-4 text-center text-sm font-medium uppercase tracking-wider text-gray-400">
@@ -13,7 +19,7 @@ export function FlagshipPills() {
       </h2>
       <ul className="flex flex-wrap justify-center gap-2">
         {FLAGSHIP_PRESETS.map((preset) => (
-          <li key={preset.op}>
+          <li key={preset.slug}>
             <Link
               href={preset.href}
               className={[

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -19,12 +19,15 @@ export function HeroDrop() {
   const [error, setError] = useState<string | null>(null);
 
   const handleFile = (file: File) => {
+    // SEAN-50: routeForFile only returns paths that resolve to a real route
+    // (matrix slug + implemented operation). Anything else falls through to
+    // the friendly error rather than routing the user to a 404.
     const target = routeForFile(file);
     if (!target) {
       const ext = extOf(file.name);
       setError(
         ext
-          ? `We don't recognise .${ext} yet. Try MOV, MP4, WebM, MP3, JPG, or HEIC.`
+          ? `We don't recognise .${ext} yet. Try MOV, MP4, WebM, MKV, AVI, FLV, WMV, M4V, or MPEG.`
           : "That file doesn't have an extension we can route on.",
       );
       return;

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -26,6 +26,7 @@ import { MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { OperationRow } from '@/ops/types';
 import { ConverterPanel } from './ConverterPanel';
 import { FAQ } from './FAQ';
+import { pathForSlug, routeExistsForSlug } from './route-registry';
 
 export interface ToolPageProps {
   row: OperationRow;
@@ -75,7 +76,7 @@ export function ToolPage({ row }: ToolPageProps) {
             {siblings.map((s) => (
               <li key={s.slug}>
                 <Link
-                  href={`/${s.operation}/${s.slug}`}
+                  href={s.href}
                   className={[
                     'flex h-full items-center justify-center rounded-xl',
                     'border border-gray-800 bg-gray-900/40 px-4 py-3',
@@ -202,33 +203,35 @@ function buildExtraArgs(row: OperationRow): Record<string, string> | undefined {
 interface SiblingLink {
   slug: string;
   label: string;
-  operation: string;
+  href: string;
 }
 
 /**
- * Resolve `row.related` slugs against the matrix. Falls back to a plain label
- * derived from the slug when a sibling row isn't in the matrix yet (Phase 2
- * will add the long-tail rows).
+ * Resolve `row.related` slugs against the matrix.
+ *
+ * SEAN-50: every sibling must be (a) present in `MATRIX_BY_SLUG` and (b) have
+ * an implemented operation route. Slugs that fail either gate are dropped
+ * rather than rendered as 404 links. The visible "Related" section hides
+ * itself when the filter empties the list.
  */
 function resolveSiblings(row: OperationRow): SiblingLink[] {
-  return (row.related ?? []).map((slug) => {
+  const out: SiblingLink[] = [];
+  for (const slug of row.related ?? []) {
     const sib = MATRIX_BY_SLUG[slug];
-    if (sib) {
-      return { slug, label: sib.h1, operation: sib.operation };
-    }
-    // Sibling row doesn't exist yet — synthesise a label from the slug.
-    return {
-      slug,
-      label: humanise(slug),
-      operation: inferOperationFromSlug(slug),
-    };
-  });
+    if (!sib) continue;
+    if (!routeExistsForSlug(slug)) continue;
+    const href = pathForSlug(slug);
+    if (!href) continue;
+    out.push({ slug, label: sib.h1, href });
+  }
+  return out;
 }
 
 /**
  * Find the inverse-direction row (e.g. `mov-to-mp4` → `mp4-to-mov`). Only
- * applies to two-format `convert` rows. Returns null when there's no clean
- * reverse (e.g. `extract-audio`, multi-input `video-to-mp4`).
+ * applies to two-format `convert` rows whose reverse slug is in the matrix
+ * AND whose route is implemented. Returns null otherwise — the converter
+ * panel hides the reverse-link CTA when this is null.
  */
 function findReverse(
   row: OperationRow,
@@ -240,44 +243,10 @@ function findReverse(
   const reverseSlug = `${outputExt}-to-${inputExt}`;
   const sib = MATRIX_BY_SLUG[reverseSlug];
   if (!sib) return null;
+  if (!routeExistsForSlug(reverseSlug)) return null;
   return {
     slug: sib.slug,
     label: sib.h1,
     operation: sib.operation,
   };
-}
-
-/** Convert a slug like `mp4-to-webm` to a plain label `MP4 → WebM`. */
-function humanise(slug: string): string {
-  return slug
-    .replace('-to-', ' → ')
-    .replace(/-/g, ' ')
-    .replace(/\b([a-z])/g, (m) => m.toUpperCase())
-    .replace(
-      /Mp4|Mov|Webm|Mkv|Mpeg|Mp3|Wav|Aac|Flac|Webp|Heic|Avif|Jpg|Png|Gif/gi,
-      (m) => m.toUpperCase(),
-    );
-}
-
-/**
- * Infer the operation prefix (URL segment) from a slug. Used when a sibling
- * row isn't in the matrix yet — we still need to render a working link.
- */
-function inferOperationFromSlug(slug: string): string {
-  if (slug.startsWith('compress-')) return 'compress';
-  if (slug.startsWith('trim-')) return 'trim';
-  if (slug.startsWith('resize-')) return 'resize';
-  if (slug.startsWith('thumbnail-')) return 'thumbnail';
-  if (slug.startsWith('contact-sheet-')) return 'contact-sheet';
-  if (slug.startsWith('image-')) return 'convert';
-  if (
-    slug.endsWith('-to-mp3') ||
-    slug.endsWith('-to-wav') ||
-    slug.endsWith('-to-aac') ||
-    slug.endsWith('-to-flac')
-  ) {
-    return slug.startsWith('video-') ? 'extract-audio' : 'convert';
-  }
-  if (slug.endsWith('-to-gif')) return 'gif';
-  return 'convert';
 }

--- a/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
@@ -1,0 +1,237 @@
+/**
+ * SEAN-50 — dead-link guard.
+ *
+ * Walks every internal link rendered on the homepage and on every generated
+ * tool page, and asserts each href resolves to an existing route.
+ *
+ * Routes are declared by `src/components/route-registry.ts`
+ * (`IMPLEMENTED_OPERATION_ROUTES`). When a new dynamic route ships, add the
+ * corresponding `Operation` value to that set in the same commit — this test
+ * will then pass for the new flagship/sibling links automatically.
+ *
+ * Test runner: `node --test` (Node 18+). No external test runner required.
+ * Run via: `node --loader ts-node/esm --test src/components/__tests__/dead-links.test.ts`
+ * (a `test:dead-links` package.json script wires this up.)
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { MATRIX } from '../../ops/matrix';
+import { FLAGSHIP_PRESETS } from '../flagship-data';
+import { extOf, routeForFile } from '../route-for-file';
+import {
+  IMPLEMENTED_OPERATION_ROUTES,
+  pathForSlug,
+  routeExistsForSlug,
+} from '../route-registry';
+
+// ─────────────────────────────────────────────────────── HELPERS ─────────────
+
+/**
+ * Build the set of paths the app is known to serve. Mirrors the file-system
+ * routes under `src/app/`. Static routes are listed verbatim; dynamic routes
+ * come from the matrix filtered by the registry.
+ *
+ * Update this list when adding a new route under `src/app/`.
+ */
+function buildKnownRoutes(): Set<string> {
+  const known = new Set<string>();
+
+  // Static routes (top-level pages).
+  known.add('/');
+
+  // Footer/header links handled by SEAN-51 — listed here so the homepage walk
+  // doesn't false-flag them. They are static stubs (or external in the case of
+  // the GitHub link), not 404s.
+  known.add('/pricing');
+  known.add('/docs');
+  known.add('/llms.txt');
+
+  // Dynamic operation routes — every matrix slug whose operation is in the
+  // implemented set.
+  for (const row of MATRIX) {
+    if (!IMPLEMENTED_OPERATION_ROUTES.has(row.operation)) continue;
+    known.add(`/${row.operation}/${row.slug}`);
+  }
+
+  return known;
+}
+
+/**
+ * Re-create the homepage's outgoing internal-link list. Mirrors `app/page.tsx`
+ * + the static layout header/footer + the HeroDrop routing table.
+ *
+ * HeroDrop links are conditional (drag a file → routes), so we synthesise one
+ * dummy file per known input extension and assert each result resolves.
+ */
+function homepageLinks(): string[] {
+  const links: string[] = [];
+
+  // Header (layout.tsx).
+  links.push('/pricing', '/docs');
+
+  // Footer (SiteFooter.tsx) — but only the internal ones; the GitHub link is
+  // external.
+  links.push('/llms.txt', '/pricing', '/docs');
+
+  // Logotype links back to /.
+  links.push('/');
+
+  // FlagshipPills.
+  for (const pill of FLAGSHIP_PRESETS) {
+    links.push(pill.href);
+  }
+
+  // HeroDrop — synthesise drops for every extension currently in the
+  // PREFERRED_TARGET_BY_EXT table. We can't import that table directly (it's
+  // module-private), so we exercise routeForFile() with a representative file
+  // per extension.
+  const candidateExts = [
+    'mov',
+    'webm',
+    'mkv',
+    'avi',
+    'flv',
+    'wmv',
+    'm4v',
+    'mpeg',
+    'mpg',
+    'mp4',
+    'jpg',
+    'jpeg',
+    'png',
+    'heic',
+    'heif',
+    'bmp',
+    'tiff',
+    'tif',
+    'wav',
+    'flac',
+    'aac',
+    'ogg',
+    'm4a',
+    'opus',
+  ];
+  for (const ext of candidateExts) {
+    const target = routeForFile({ name: `dummy.${ext}` });
+    if (target) links.push(target);
+  }
+
+  return links;
+}
+
+/**
+ * Re-create every internal link a generated tool page would emit. Mirrors
+ * `ToolPage.tsx`:
+ *   - sibling Related links (filtered through `routeExistsForSlug` already)
+ *   - reverse-link (rendered by ResultBlock when present)
+ */
+function toolPageLinks(): string[] {
+  const links: string[] = [];
+
+  for (const row of MATRIX) {
+    if (!IMPLEMENTED_OPERATION_ROUTES.has(row.operation)) continue;
+
+    // Siblings.
+    for (const slug of row.related ?? []) {
+      if (!routeExistsForSlug(slug)) continue;
+      const href = pathForSlug(slug);
+      if (href) links.push(href);
+    }
+
+    // Reverse-link, if it exists.
+    if (row.operation === 'convert' && row.inputFormats.length === 1) {
+      const inputExt = row.inputFormats[0];
+      const reverseSlug = `${row.outputFormat}-to-${inputExt}`;
+      if (routeExistsForSlug(reverseSlug)) {
+        const href = pathForSlug(reverseSlug);
+        if (href) links.push(href);
+      }
+    }
+  }
+
+  return links;
+}
+
+// ─────────────────────────────────────────────────────── TESTS ───────────────
+
+describe('SEAN-50 dead-links — every internal link resolves', () => {
+  const knownRoutes = buildKnownRoutes();
+
+  it('every homepage link points at a real route', () => {
+    const links = homepageLinks();
+    assert.ok(links.length > 0, 'homepage should emit at least one link');
+    for (const href of links) {
+      assert.ok(
+        knownRoutes.has(href),
+        `homepage link ${href} does not resolve to a real route`,
+      );
+    }
+  });
+
+  it('every generated tool-page link points at a real route', () => {
+    const links = toolPageLinks();
+    // Phase 1 only ships convert routes — at least the flagship convert pages
+    // (mov-to-mp4, mp4-to-webm, webm-to-mp4) emit siblings, so the count
+    // should be >0. If this assertion fires after a matrix change, either a
+    // new route landed (good — bump `IMPLEMENTED_OPERATION_ROUTES`) or
+    // related-slugs got filtered out (also good — the test is doing its job).
+    assert.ok(
+      links.length > 0,
+      'tool pages should emit at least one related/reverse link',
+    );
+    for (const href of links) {
+      assert.ok(
+        knownRoutes.has(href),
+        `tool-page link ${href} does not resolve to a real route`,
+      );
+    }
+  });
+
+  it('routeForFile only returns paths that resolve', () => {
+    // Walk every plausible extension. routeForFile returns null for unknown
+    // ones — that's fine. Anything it returns must be a real route.
+    const exts = [
+      'mov',
+      'webm',
+      'mkv',
+      'avi',
+      'flv',
+      'wmv',
+      'm4v',
+      'mpeg',
+      'mpg',
+      'mp4',
+      'jpg',
+      'jpeg',
+      'png',
+      'heic',
+      'heif',
+      'bmp',
+      'tiff',
+      'tif',
+      'wav',
+      'flac',
+      'aac',
+      'ogg',
+      'm4a',
+      'opus',
+      'unknown-ext',
+    ];
+    for (const ext of exts) {
+      const target = routeForFile({ name: `dummy.${ext}` });
+      if (target === null) continue;
+      assert.ok(
+        knownRoutes.has(target),
+        `routeForFile('.${ext}') returned ${target} which does not resolve`,
+      );
+    }
+  });
+
+  it('extOf normalises common extension shapes', () => {
+    assert.equal(extOf('foo.MP4'), 'mp4');
+    assert.equal(extOf('bare'), '');
+    assert.equal(extOf('a.b.tiff'), 'tiff');
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/flagship-data.ts
+++ b/apps/ffmpeg-converter/web/src/components/flagship-data.ts
@@ -1,40 +1,49 @@
-// Hardcoded flagship presets for the homepage pill row.
+// Homepage flagship pill row — derived from the operations matrix.
 //
-// Source: apps/ffmpeg-converter/docs/STRATEGY.md §"Flagship 8–12 headline
-// conversions". Twelve presets, two rows of six on desktop.
+// Source: `MATRIX`/`FLAGSHIP_PRESETS` in `@/ops/matrix`. SEAN-50 replaced the
+// hardcoded list with a matrix-derived one so we can never ship a pill that
+// points at a non-existent route. Flagship rows whose operation route hasn't
+// been implemented yet are filtered out — they'll appear automatically when
+// the matching `app/[op]/[slug]/page.tsx` route lands.
 //
-// This file is intentionally hardcoded — Phase 1 does not depend on the typed
-// operations matrix (SEAN-38). When the matrix lands, a follow-up ticket will
-// derive these pills from the matrix instead of duplicating the data here.
+// Twelve presets max (per `apps/ffmpeg-converter/docs/STRATEGY.md` "Flagship
+// 8-12 headline conversions"). Some flagships will not render in Phase 1 —
+// they reappear when their operation route ships.
 
-export type FlagshipPreset = {
+import {
+  MATRIX_BY_SLUG,
+  FLAGSHIP_PRESETS as MATRIX_FLAGSHIPS,
+} from '@/ops/matrix';
+import { pathForSlug, routeExistsForSlug } from './route-registry';
+
+export interface FlagshipPreset {
   /** Short label used on the pill button. */
   label: string;
-  /** Tool-page slug (relative to /, no leading slash). */
+  /** Tool-page path (with leading slash), guaranteed to resolve. */
   href: string;
   /** Op identifier from the Go backend's ops registry. */
   op: string;
-};
+  /** Matrix slug — used as a stable React key. */
+  slug: string;
+}
 
-export const FLAGSHIP_PRESETS: FlagshipPreset[] = [
-  { label: 'MP4 → WebM', href: '/convert/mp4-to-webm', op: 'transcode_webm' },
-  { label: 'MOV → MP4', href: '/convert/mov-to-mp4', op: 'transcode' },
-  { label: 'MP4 → GIF', href: '/gif/mp4-to-gif', op: 'gif_from_video' },
-  { label: 'Video → MP3', href: '/extract-audio/mp4-to-mp3', op: 'audio_mp3' },
-  {
-    label: 'Shrink for Discord',
-    href: '/compress/mp4-under-10mb',
-    op: 'change_bitrate',
+/**
+ * Flagship pills filtered to rows whose route is implemented today. As more
+ * operation routes ship (Phase 2), more pills will surface automatically.
+ */
+export const FLAGSHIP_PRESETS: FlagshipPreset[] = MATRIX_FLAGSHIPS.flatMap(
+  (row) => {
+    if (!MATRIX_BY_SLUG[row.slug]) return [];
+    if (!routeExistsForSlug(row.slug)) return [];
+    const href = pathForSlug(row.slug);
+    if (!href) return [];
+    return [
+      {
+        label: row.flagship?.label ?? row.h1,
+        href,
+        op: row.goOp,
+        slug: row.slug,
+      },
+    ];
   },
-  { label: 'Grab a thumbnail', href: '/thumbnail/mp4', op: 'thumbnail' },
-  { label: 'Trim a clip', href: '/trim/mp4', op: 'trim' },
-  { label: 'Resize', href: '/resize/mp4', op: 'resize' },
-  { label: 'Image → WebP', href: '/convert/jpg-to-webp', op: 'image_to_webp' },
-  { label: 'HEIC/PNG → JPG', href: '/convert/heic-to-jpg', op: 'image_to_jpg' },
-  {
-    label: 'Normalise audio',
-    href: '/audio/normalize-mp3',
-    op: 'normalize_audio',
-  },
-  { label: 'Contact sheet', href: '/contact-sheet/mp4', op: 'contact_sheet' },
-];
+);

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -4,43 +4,63 @@
 // should send the user to. Spec §7.1: "dropping a .mov on the homepage routes
 // to /convert/mov-to-mp4".
 //
-// The mapping is intentionally minimal in Phase 1 — Phase 2 will expand it
-// from the typed operations matrix (SEAN-38). Anything we don't recognise
-// goes to the generic /convert page (which doesn't exist yet — Phase 2 ships
-// it). For now, an unknown extension falls back to a search-style URL the
-// user can route from manually.
+// SEAN-50: every candidate target must resolve to an existing route. We gate
+// the lookup on `MATRIX_BY_SLUG` and `IMPLEMENTED_OPERATION_ROUTES` rather
+// than maintaining a hand-rolled extension map that drifts out of sync with
+// the matrix. Anything not covered by the matrix returns `null`, and the
+// caller surfaces a "we don't recognise this format yet" message.
 
-const EXT_DEFAULT_TARGET: Record<string, string> = {
-  // Video → MP4 by default. MOV is the headline case (iPhone footage).
-  mov: '/convert/mov-to-mp4',
-  webm: '/convert/webm-to-mp4',
-  mkv: '/convert/mkv-to-mp4',
-  avi: '/convert/avi-to-mp4',
-  flv: '/convert/flv-to-mp4',
-  wmv: '/convert/wmv-to-mp4',
-  m4v: '/convert/m4v-to-mp4',
-  mpeg: '/convert/mpeg-to-mp4',
-  mpg: '/convert/mpg-to-mp4',
-  // MP4 → most-asked sibling: WebM (browser-native).
-  mp4: '/convert/mp4-to-webm',
+import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
+import type { Format } from '@/ops/types';
+import { pathForSlug, routeExistsForSlug } from './route-registry';
 
-  // Image → WebP is the modern web default.
-  jpg: '/convert/jpg-to-webp',
-  jpeg: '/convert/jpg-to-webp',
-  png: '/convert/png-to-webp',
-  heic: '/convert/heic-to-jpg',
-  heif: '/convert/heic-to-jpg',
-  bmp: '/convert/bmp-to-jpg',
-  tiff: '/convert/tiff-to-jpg',
-  tif: '/convert/tiff-to-jpg',
+/**
+ * Default target output for each input extension. The matrix decides whether
+ * a `${ext}-to-${target}` slug actually exists — these are just preference
+ * hints (e.g. iPhone HEIC photos default to JPG, not WebP, because that's
+ * what most users actually want).
+ */
+const PREFERRED_TARGET_BY_EXT: Record<string, Format> = {
+  // Video: MP4 is the universal default.
+  mov: 'mp4',
+  webm: 'mp4',
+  mkv: 'mp4',
+  avi: 'mp4',
+  flv: 'mp4',
+  wmv: 'mp4',
+  m4v: 'mp4',
+  mpeg: 'mp4',
+  mpg: 'mp4',
+  // MP4 → WebM (browser-native, smaller).
+  mp4: 'webm',
 
-  // Audio → MP3 by default (universal).
-  wav: '/convert/wav-to-mp3',
-  flac: '/convert/flac-to-mp3',
-  aac: '/convert/aac-to-mp3',
-  ogg: '/convert/ogg-to-mp3',
-  m4a: '/convert/m4a-to-mp3',
-  opus: '/convert/opus-to-mp3',
+  // Image: WebP for the modern web; HEIC defaults to JPG (compatibility).
+  jpg: 'webp',
+  jpeg: 'webp',
+  png: 'webp',
+  heic: 'jpg',
+  heif: 'jpg',
+  bmp: 'jpg',
+  tiff: 'jpg',
+  tif: 'jpg',
+
+  // Audio: MP3 is universal.
+  wav: 'mp3',
+  flac: 'mp3',
+  aac: 'mp3',
+  ogg: 'mp3',
+  m4a: 'mp3',
+  opus: 'mp3',
+};
+
+// Some input extensions normalise to a different `Format` enum value (the
+// matrix uses canonical names). Phase 1 only needs `jpeg → jpg`, `mpg → mpeg`,
+// `tif → tiff`, `heif → heic`. Anything else is a one-to-one mapping.
+const EXT_TO_FORMAT: Record<string, string> = {
+  jpeg: 'jpg',
+  mpg: 'mpeg',
+  tif: 'tiff',
+  heif: 'heic',
 };
 
 /**
@@ -55,12 +75,38 @@ export function extOf(filename: string): string {
 
 /**
  * Pick the tool-page path to route to for a given file. Returns `null` when
- * the extension isn't in our table — the caller should surface a friendly
- * "we don't recognise this format" message rather than dumping the user on a
- * 404.
+ *   - the file has no extension
+ *   - the extension isn't in our preference table
+ *   - the matrix has no `${ext}-to-${target}` row
+ *   - the matrix row exists but its operation route isn't implemented yet
+ *
+ * The caller should surface a friendly "we don't recognise this format yet"
+ * message rather than dumping the user on a 404.
  */
 export function routeForFile(file: File | { name: string }): string | null {
   const ext = extOf(file.name);
   if (!ext) return null;
-  return EXT_DEFAULT_TARGET[ext] ?? null;
+
+  const inputFormat = EXT_TO_FORMAT[ext] ?? ext;
+  const target = PREFERRED_TARGET_BY_EXT[ext];
+  if (!target) return null;
+
+  // Try the direct `${input}-to-${target}` slug first.
+  const directSlug = `${inputFormat}-to-${target}`;
+  if (routeExistsForSlug(directSlug)) {
+    return pathForSlug(directSlug);
+  }
+
+  // Fall back to multi-input rows like `video-to-mp4` (covers mkv/avi/flv/wmv
+  // /m4v/mpeg → mp4 from a single matrix row).
+  for (const row of MATRIX) {
+    if (row.operation !== 'convert') continue;
+    if (row.outputFormat !== target) continue;
+    if (!row.inputFormats.includes(inputFormat as Format)) continue;
+    if (!MATRIX_BY_SLUG[row.slug]) continue;
+    if (!routeExistsForSlug(row.slug)) continue;
+    return pathForSlug(row.slug);
+  }
+
+  return null;
 }

--- a/apps/ffmpeg-converter/web/src/components/route-registry.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-registry.ts
@@ -1,0 +1,43 @@
+// Single source of truth for which internal routes actually resolve today.
+//
+// Phase 1 ships only `/convert/[slug]`. Phase 2 will add /compress/[slug],
+// /extract-audio/[slug], /gif/[slug] etc — when those page routes land, add
+// their `Operation` value to `IMPLEMENTED_OPERATION_ROUTES` in the same commit.
+//
+// Used by HeroDrop, FlagshipPills, and ToolPage to gate every internal link on
+// "is the destination route actually implemented + is the slug in the matrix".
+// The dead-links test imports this module and walks every emitted Link.
+
+import { MATRIX_BY_SLUG } from '@/ops/matrix';
+import type { Operation } from '@/ops/types';
+
+/**
+ * Operations that have a corresponding `app/[op]/[slug]/page.tsx` route. Add
+ * to this list when shipping a new dynamic route — never add an operation here
+ * without also shipping its route, or links will 404.
+ */
+export const IMPLEMENTED_OPERATION_ROUTES: ReadonlySet<Operation> =
+  new Set<Operation>(['convert']);
+
+/**
+ * Returns true when there is an existing matrix row for `slug` AND the row's
+ * operation has a generated route. Use this to gate every dynamic link the UI
+ * emits.
+ */
+export function routeExistsForSlug(slug: string): boolean {
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row) return false;
+  return IMPLEMENTED_OPERATION_ROUTES.has(row.operation);
+}
+
+/**
+ * Build the canonical path for a matrix slug, or `null` when the route does
+ * not exist yet. Centralised here so we never hand-roll `/${operation}/${slug}`
+ * at the call site (and silently desync when the registry changes).
+ */
+export function pathForSlug(slug: string): string | null {
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row) return null;
+  if (!IMPLEMENTED_OPERATION_ROUTES.has(row.operation)) return null;
+  return `/${row.operation}/${row.slug}`;
+}

--- a/apps/ffmpeg-converter/web/tsconfig.test.json
+++ b/apps/ffmpeg-converter/web/tsconfig.test.json
@@ -1,0 +1,26 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "jsx": "preserve",
+    "noEmit": true
+  },
+  "ts-node": {
+    "transpileOnly": true,
+    "require": ["tsconfig-paths/register"],
+    "compilerOptions": {
+      "module": "CommonJS",
+      "moduleResolution": "node",
+      "baseUrl": ".",
+      "paths": {
+        "@/*": ["./src/*"]
+      }
+    }
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #50

## Summary
- Centralise route gating in a new `route-registry` module (`IMPLEMENTED_OPERATION_ROUTES`, `routeExistsForSlug`, `pathForSlug`). HeroDrop, FlagshipPills, and ToolPage all consult it before emitting an internal link.
- `route-for-file.ts` now drops the hand-rolled extension table and looks up the matrix directly — extensions whose slug isn't in `MATRIX_BY_SLUG` (or whose operation route isn't implemented yet) return `null`, which HeroDrop surfaces as the existing "we don't recognise this format" message instead of routing to a 404.
- `flagship-data.ts` is rebuilt off matrix `FLAGSHIP_PRESETS`, filtered to rows whose operation route exists today; pills appear automatically as new routes ship.
- `ToolPage` siblings and the reverse-link CTA are filtered through `routeExistsForSlug`; the "Related" section hides when the filter empties the list. Removed the dead `humanise`/`inferOperationFromSlug` synthesised-sibling fallback that was emitting 404 links.
- Added `dead-links.test.ts` (Node `node:test` + ts-node) that walks every link emitted on the homepage and on every generated tool page and asserts each path resolves to a real route. Runs via `yarn test:dead-links`.

## Test plan
- [ ] `cd apps/ffmpeg-converter/web && yarn test:dead-links` — passes 4/4 subtests.
- [ ] `cd apps/ffmpeg-converter/web && yarn build` — Next compiles + lints + collects route metadata cleanly (prerender ENOSPC on this dev box is unrelated to link validity).
- [ ] Spot-check homepage: only the four implemented `/convert/...` flagships render (`MOV → MP4`, `MP4 → WebM`, `Image → WebP`, `HEIC/PNG → JPG`); `/gif/...`, `/extract-audio/...`, etc. pills are hidden.
- [ ] Drop a `.heic` on the homepage — UI shows the unrecognised-format message rather than navigating to a 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)