### PR TITLE
[SEAN-58] feat: per-page Open Graph image generated at build time

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/compress/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/compress/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/compress/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['compress'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'compress').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/compress/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/compress/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/compress/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['compress'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'compress').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/contact-sheet/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['contact-sheet'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'contact-sheet').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/contact-sheet/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/contact-sheet/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['contact-sheet'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'contact-sheet').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/convert/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/convert/[slug]/opengraph-image.tsx
@@ -1,0 +1,32 @@
+// Per-page Open Graph image for `/convert/[slug]` — generated at build time.
+//
+// Co-located with `page.tsx` so Next pre-renders one PNG per slug. The
+// <head>'s `og:image` meta is auto-wired by Next — no manual <meta> tag needed.
+//
+// Accepts both `convert` and `image-convert` operations to match the parent
+// route's gate (see `page.tsx` for the verb-first slug rationale).
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['convert', 'image-convert'] as const;
+
+// Drives build-time generation: one image per matching matrix slug.
+export function generateStaticParams() {
+  return MATRIX.filter((row) =>
+    (ACCEPTED as readonly string[]).includes(row.operation),
+  ).map((row) => ({ slug: row.slug }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/convert/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/convert/[slug]/twitter-image.tsx
@@ -1,0 +1,30 @@
+// Per-page Twitter card image for `/convert/[slug]` — generated at build time.
+//
+// Twitter accepts the OG image, but a dedicated `twitter-image.tsx` lets us
+// emit `twitter:image` distinct from `og:image` and improves rendering on
+// X / Slack / Discord previews. We share the same template — sizing and
+// styling are identical to the OG image.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['convert', 'image-convert'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) =>
+    (ACCEPTED as readonly string[]).includes(row.operation),
+  ).map((row) => ({ slug: row.slug }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/extract-audio/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['extract-audio'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'extract-audio').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/extract-audio/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/extract-audio/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['extract-audio'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'extract-audio').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/gif/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/gif/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/gif/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['gif'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'gif').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/gif/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/gif/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/gif/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['gif'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'gif').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/normalize-audio/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['normalize-audio'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'normalize-audio').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/normalize-audio/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/normalize-audio/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['normalize-audio'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'normalize-audio').map(
+    (row) => ({ slug: row.slug }),
+  );
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/resize/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/resize/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/resize/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['resize'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'resize').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/resize/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/resize/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/resize/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['resize'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'resize').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/thumbnail/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['thumbnail'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'thumbnail').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/thumbnail/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/thumbnail/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['thumbnail'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'thumbnail').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/trim/[slug]/opengraph-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/trim/[slug]/opengraph-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Open Graph image for `/trim/[slug]` — generated at build time.
+// See `/convert/[slug]/opengraph-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['trim'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'trim').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function OpengraphImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/app/trim/[slug]/twitter-image.tsx
+++ b/apps/ffmpeg-converter/web/src/app/trim/[slug]/twitter-image.tsx
@@ -1,0 +1,26 @@
+// Per-page Twitter card image for `/trim/[slug]` — generated at build time.
+// See `/convert/[slug]/twitter-image.tsx` for the full pattern rationale.
+
+import { generateOgImage } from '@/components/og-image-handler';
+import { OG_CONTENT_TYPE, OG_SIZE } from '@/components/og-template';
+import { MATRIX } from '@/ops/matrix';
+
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const alt = "Sean's Converter — per-pair conversion preview";
+
+const ACCEPTED = ['trim'] as const;
+
+export function generateStaticParams() {
+  return MATRIX.filter((row) => row.operation === 'trim').map((row) => ({
+    slug: row.slug,
+  }));
+}
+
+interface Props {
+  params: { slug: string };
+}
+
+export default function TwitterImage({ params }: Props) {
+  return generateOgImage(ACCEPTED, params.slug);
+}

--- a/apps/ffmpeg-converter/web/src/components/og-image-handler.tsx
+++ b/apps/ffmpeg-converter/web/src/components/og-image-handler.tsx
@@ -1,0 +1,60 @@
+// Shared route handler for `opengraph-image.tsx` / `twitter-image.tsx` files.
+//
+// Every operation route under `src/app/{op}/[slug]/` exposes an OG image that
+// resolves the slug against MATRIX_BY_SLUG and renders the shared OgTemplate.
+// This module factors out the boilerplate so each route file is a 4-liner.
+//
+// Usage (in `src/app/convert/[slug]/opengraph-image.tsx`):
+//
+//   import { generateOgImage, generateOgStaticParams } from '...';
+//   export const runtime = 'nodejs';
+//   export const size = OG_SIZE;
+//   export const contentType = OG_CONTENT_TYPE;
+//   export function generateImageMetadata() { ... }
+//   export default function Image({ params }) {
+//     return generateOgImage(['convert', 'image-convert'], params.slug);
+//   }
+//
+// Static generation: each `opengraph-image.tsx` co-located with `[slug]/page.tsx`
+// inherits the parent route's `generateStaticParams` — Next pre-renders one
+// image per slug at build time. We don't need to redeclare it here.
+
+import { ImageResponse } from 'next/og';
+import { MATRIX_BY_SLUG } from '@/ops/matrix';
+import type { Operation } from '@/ops/types';
+import { OG_SIZE, OgTemplate } from './og-template';
+
+/**
+ * Render the OG image for a given slug, gated to a list of accepted ops.
+ * Mirrors the per-route gate in `[slug]/page.tsx` — if the slug doesn't
+ * resolve or its operation isn't in `acceptedOps`, returns a tiny fallback
+ * image (Next requires *some* response from this handler).
+ */
+export function generateOgImage(
+  acceptedOps: readonly Operation[],
+  slug: string,
+): ImageResponse {
+  const row = MATRIX_BY_SLUG[slug];
+  if (!row || !acceptedOps.includes(row.operation)) {
+    return new ImageResponse(
+      <div
+        style={{
+          display: 'flex',
+          height: '100%',
+          width: '100%',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundColor: '#0a0a0a',
+          color: '#f5f5f5',
+          fontSize: 64,
+          fontFamily: 'sans-serif',
+        }}
+      >
+        Sean&apos;s Converter
+      </div>,
+      { ...OG_SIZE },
+    );
+  }
+
+  return new ImageResponse(<OgTemplate row={row} />, { ...OG_SIZE });
+}

--- a/apps/ffmpeg-converter/web/src/components/og-template.tsx
+++ b/apps/ffmpeg-converter/web/src/components/og-template.tsx
@@ -1,0 +1,128 @@
+// Shared Open Graph / Twitter image template.
+//
+// Rendered by `next/og`'s `ImageResponse` at build time from each operation's
+// `opengraph-image.tsx` / `twitter-image.tsx` route handler. Co-located with
+// each `[slug]/page.tsx` so Next pre-renders one image per matrix slug
+// (generateStaticParams driven — no runtime cost).
+//
+// Constraints (per SEAN-58 AC):
+//   - 1200×630 (standard OG card, also Twitter `summary_large_image` size).
+//   - System fonts only — no font fetching at build (Next allows omitting
+//     the `fonts` option, which falls back to a built-in default font).
+//   - Shows the row's H1 (e.g. "MOV → MP4") prominently plus a "Sean's
+//     Converter" wordmark.
+//
+// The exported `OG_SIZE` and `OG_CONTENT_TYPE` constants are re-used by every
+// `opengraph-image.tsx` / `twitter-image.tsx` to satisfy Next's metadata API.
+
+import type { OperationRow } from '@/ops/types';
+
+export const OG_SIZE = { width: 1200, height: 630 } as const;
+export const OG_CONTENT_TYPE = 'image/png' as const;
+
+/**
+ * Convert the matrix row's H1 ("MOV to MP4", "Compress MP4", "Image to WebP")
+ * into a punchier OG headline. We swap the word "to" for an arrow when both
+ * sides are short tokens — that's the per-pair pitch the AC calls out.
+ */
+function ogHeadline(row: OperationRow): string {
+  const h1 = row.h1;
+  // "X to Y" → "X → Y" (only when X and Y look like simple format tokens).
+  const arrowed = h1.replace(/^(\S{1,8})\s+to\s+(\S{1,8})$/i, '$1 → $2');
+  return arrowed;
+}
+
+interface OgTemplateProps {
+  row: OperationRow;
+}
+
+/**
+ * The JSX returned here is consumed by `ImageResponse` from `next/og`, which
+ * supports a *subset* of CSS via Satori — flexbox layouts only, no grid, no
+ * external assets unless explicitly fetched. Keep this template self-contained.
+ */
+export function OgTemplate({ row }: OgTemplateProps) {
+  return (
+    <div
+      style={{
+        height: '100%',
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'space-between',
+        backgroundColor: '#0a0a0a',
+        backgroundImage:
+          'radial-gradient(circle at 25% 25%, #1a1a1a 0%, #0a0a0a 60%)',
+        padding: '72px',
+        color: '#f5f5f5',
+        fontFamily: 'sans-serif',
+      }}
+    >
+      {/* Top row: wordmark */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          fontSize: 28,
+          fontWeight: 700,
+          letterSpacing: '-0.01em',
+          color: '#a3a3a3',
+        }}
+      >
+        Sean&apos;s Converter
+      </div>
+
+      {/* Centre block: H1 + value prop */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 120,
+            fontWeight: 800,
+            letterSpacing: '-0.04em',
+            lineHeight: 1.0,
+            color: '#fafafa',
+          }}
+        >
+          {ogHeadline(row)}
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            fontSize: 36,
+            fontWeight: 500,
+            color: '#d4d4d4',
+            lineHeight: 1.2,
+            maxWidth: 1000,
+          }}
+        >
+          {row.valueProp}
+        </div>
+      </div>
+
+      {/* Bottom row: badges */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 16,
+          fontSize: 24,
+          fontWeight: 600,
+          color: '#737373',
+        }}
+      >
+        <div style={{ display: 'flex' }}>Free</div>
+        <div style={{ display: 'flex' }}>·</div>
+        <div style={{ display: 'flex' }}>No watermark</div>
+        <div style={{ display: 'flex' }}>·</div>
+        <div style={{ display: 'flex' }}>No signup</div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #58

## Summary
- Co-located `opengraph-image.tsx` + `twitter-image.tsx` with every operation route under `src/app/{op}/[slug]/` (convert, compress, extract-audio, gif, trim, resize, thumbnail, contact-sheet, normalize-audio).
- Shared `og-template.tsx` renders a 1200×630 PNG showing the row's H1 (e.g. "MOV → MP4") plus the "Sean's Converter" wordmark and a "Free · No watermark · No signup" badge row. System fonts only (no fetched assets).
- Each route file declares its own `generateStaticParams` so Next builds one PNG per matrix slug at build time — no runtime cost.

## Test plan
- [x] `tsc --noEmit` clean for `apps/ffmpeg-converter/web`
- [x] `next build` emits `[op]/[slug]/opengraph-image` and `[op]/[slug]/twitter-image` as SSG (●) routes for every matrix slug
- [x] `.next/server/app/convert/mov-to-mp4/opengraph-image.body` is a real `PNG image data, 1200 x 630, 8-bit/color RGBA` file
- [x] Rendered HTML head for `/convert/mov-to-mp4` contains both `<meta property="og:image" ...>` and `<meta name="twitter:image" ...>` with width/height/type/alt
- [x] `yarn test:dead-links` passes
- [ ] Manual spot-check: paste `https://seansconverter.com/convert/mov-to-mp4` in Slack/Discord post-deploy → rich preview shows the per-pair OG card

🤖 Generated with [Claude Code](https://claude.com/claude-code)