### PR TITLE
[SEAN-49] fix: dead references to deleted spec-2026-05-05.md

### DIFF
--- a/apps/ffmpeg-converter/phased-spec.md
+++ b/apps/ffmpeg-converter/phased-spec.md
@@ -1,10 +1,10 @@
 # Sean's Converter — Phased Build Plan
 
-> Working delivery doc. Turns the vision in [`spec-2026-05-05.md`](./spec-2026-05-05.md) into ticket-sized phases, accounting for what already exists in this directory. Hand this to a ticket-writing agent.
+> Working delivery doc. Turns the original vision (preserved in git at commit `058ab8c` as `spec-2026-05-05.md`, since superseded by this file) into ticket-sized phases, accounting for what already exists in this directory. Hand this to a ticket-writing agent.
 
 ## Reference reading (in priority order)
 
-- [`spec-2026-05-05.md`](./spec-2026-05-05.md) — vision, non-negotiables, voice, URL architecture, schema list, anti-goals. Source of truth for the *why*.
+- Original vision spec — preserved only in git history at commit `058ab8c` (file `apps/ffmpeg-converter/spec-2026-05-05.md`). Captured the *why*: non-negotiables, voice, URL architecture, schema list, anti-goals. Its content has been folded into this doc; the dated file no longer exists in the working tree.
 - [`docs/STRATEGY.md`](./docs/STRATEGY.md) — simplicity vs fractal-options tradeoff, the 12 flagship presets, repeat-customer hooks, wasm-vs-server tiering rules.
 - [`docs/COMPETITORS.md`](./docs/COMPETITORS.md) — competitor numbers; source for the comparison table.
 - [`README.md`](./README.md) — current Go service shape and op registry.
@@ -21,7 +21,7 @@ Why this is the right architecture and stays the right architecture:
 - **Operations simplicity is a moat.** Cloudconvert et al. burn engineering time on infra that doesn't differentiate. We don't. Every hour not spent on Redis cluster topology is an hour spent shipping recipes and pSEO pages.
 - **Backups are `cp seans-converter.db ./backup/`.** That's the whole disaster-recovery plan.
 
-**Where this doc disagrees with [`spec-2026-05-05.md`](./spec-2026-05-05.md) on hosting/persistence/scale, this doc wins.** The dated spec preserves the vision (three doors, no watermark, MCP, AEO). Stack choices in §4 of that doc — Postgres, Redis, S3, Vercel, Fly worker fleet — are superseded by the architecture above.
+**Where this doc disagrees with the original vision spec (commit `058ab8c`) on hosting/persistence/scale, this doc wins.** That spec preserved the vision (three doors, no watermark, MCP, AEO). Its §4 stack choices — Postgres, Redis, S3, Vercel, Fly worker fleet — are superseded by the architecture above.
 
 We revisit this only when measured load on the home server forces it. Not before. Not "just in case".
 
@@ -234,7 +234,7 @@ Don't let scope drift back in via tickets. If you find yourself writing one of t
 
 ## Plan of action
 
-1. **Now (this commit):** `new-spec.md` renamed to `spec-2026-05-05.md`. This file is the working delivery doc. The dated spec is the immutable vision; this file is the moving plan.
+1. **Now (this commit):** the dated vision spec has been folded into this doc and removed from the working tree (preserved at commit `058ab8c` for archaeology). This file is the working delivery doc and the moving plan.
 2. **Next session:** spawn a ticket-writing agent. Scope: Phase 0 + Phase 1 only. Each deliverable above maps to roughly one ticket — split if obviously bigger (e.g. "Postgres schema" might be schema + migration tooling). Do not write tickets past Phase 1 yet — let the plan absorb learnings before committing more.
 3. **Per-phase rules:**
    - One phase = one GitHub Project milestone.

--- a/apps/ffmpeg-converter/web/src/ops/matrix.ts
+++ b/apps/ffmpeg-converter/web/src/ops/matrix.ts
@@ -2,7 +2,8 @@
  * Operations matrix — single source of truth for pSEO page generation.
  *
  * Schema is defined in `./types.ts` and mirrors §6 of the original vision spec
- * (preserved in git at commit 058ab8c, file `apps/ffmpeg-converter/spec-2026-05-05.md`).
+ * (folded into `phased-spec.md`; dated source doc lives only in git history at
+ * commit 058ab8c).
  *
  * Phase 1 (this ticket): curated subset covering at minimum the four ops named
  * in `phased-spec.md` Phase 1 — `convert`, `compress`, `extract-audio`, `gif` —

--- a/apps/ffmpeg-converter/web/src/ops/types.ts
+++ b/apps/ffmpeg-converter/web/src/ops/types.ts
@@ -5,9 +5,10 @@
  * or more static pages under `/convert/...`, `/compress/...`, `/extract-audio/...`,
  * `/gif/...`, etc.
  *
- * Schema mirrors §6 of the original vision spec (`spec-2026-05-05.md`, preserved
- * in git history at commit 058ab8c) — extended with the metadata that Phase 2
- * page generation needs (intent volume, FAQ blocks, related-page slugs, presets).
+ * Schema mirrors §6 of the original vision spec (folded into `phased-spec.md`;
+ * the dated source doc lives only in git history at commit 058ab8c) — extended
+ * with the metadata that Phase 2 page generation needs (intent volume, FAQ
+ * blocks, related-page slugs, presets).
  *
  * The Go backend's op identifiers (`transcode`, `transcode_webm`, `gif_from_video`,
  * etc.) live in `apps/ffmpeg-converter/ops.go`. The `goOp` field on each row binds


### PR DESCRIPTION
Closes #49

## Summary
- Replace broken `[…](./spec-2026-05-05.md)` markdown links in `phased-spec.md` with prose pointing at git commit `058ab8c`.
- Update comments in `web/src/ops/matrix.ts` and `web/src/ops/types.ts` so they no longer imply the dated spec file is still in the working tree (file was deleted in commit `30ac72c`).
- Comment-only changes in TS files; no logic touched.

## Test plan
- [x] `grep -rn "](\./spec-2026-05-05\.md)" apps/ffmpeg-converter/` returns zero matches
- [x] Remaining `spec-2026-05-05.md` references are historical commit-hash citations only
- [x] `tsc --noEmit` passes for `apps/ffmpeg-converter/web`
- [x] Biome check clean for the three modified files