### PR TITLE
[SEAN-59] feat: 301 redirects for slug misspellings

### DIFF
--- a/apps/ffmpeg-converter/web/next.config.ts
+++ b/apps/ffmpeg-converter/web/next.config.ts
@@ -1,4 +1,6 @@
 import type { NextConfig } from 'next';
+import { MATRIX } from './src/ops/matrix';
+import { generateRedirects } from './src/ops/redirects';
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -9,6 +11,19 @@ const nextConfig: NextConfig = {
   // route at src/app/api/[...slug]/route.ts handles same-origin proxying
   // AND falls back to an in-memory mock when the Go backend is offline,
   // mirroring the legacy web-spa/dev.ts behaviour.
+
+  /**
+   * SEAN-59 — 301 redirects from common slug misspellings to canonical pages.
+   *
+   * Generated programmatically from the operations matrix; adding a new
+   * canonical from-to row automatically produces the four misspelling
+   * redirects (`mp4tomov`, `mp4-mov`, `mp4_mov`, `convert-mp4-mov`) for it.
+   *
+   * Runs at the edge — no per-request JS. See `src/ops/redirects.ts`.
+   */
+  async redirects() {
+    return generateRedirects(MATRIX);
+  },
 };
 
 export default nextConfig;

--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -11,7 +11,8 @@
     "test:dead-links": "ts-node -P tsconfig.test.json src/components/__tests__/dead-links.test.ts",
     "test:matrix": "ts-node -P tsconfig.test.json src/ops/matrix.test.ts",
     "test:sitemap": "ts-node -P tsconfig.test.json src/ops/sitemap.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap"
+    "test:redirects": "ts-node -P tsconfig.test.json src/ops/redirects.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/ops/redirects.test.ts
+++ b/apps/ffmpeg-converter/web/src/ops/redirects.test.ts
@@ -1,0 +1,148 @@
+/**
+ * SEAN-59 — slug-misspelling redirect generator tests.
+ *
+ * Verifies the contract `next.config.ts` relies on:
+ *   1. ≥200 redirects produced from the matrix (≥50 canonical from-to slugs
+ *      × 4 misspelling patterns = ≥200).
+ *   2. Every redirect is `permanent: true` (i.e. 301).
+ *   3. No redirect source collides with a canonical URL — must never shadow
+ *      a real page.
+ *   4. The four misspelling patterns are present for a sample row
+ *      (`mov-to-mp4`).
+ *   5. No duplicate sources — `redirects()` would silently drop them anyway,
+ *      but a duplicate is a sign of a generator bug.
+ *
+ * Test runner: `node:test` invoked via the same `ts-node`-based pattern as
+ * the other tests in this folder. Wired up in package.json as
+ * `yarn test:redirects` and aggregated into `yarn test`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { MATRIX } from './matrix';
+import {
+  canonicalPathsForTest,
+  generateRedirects,
+  type RedirectRule,
+} from './redirects';
+
+// ─────────────────────────────────────────────────────── TESTS ───────────────
+
+describe('SEAN-59 misspelling redirects', () => {
+  const redirects: RedirectRule[] = generateRedirects(MATRIX);
+  const canonicalPaths = canonicalPathsForTest(MATRIX);
+
+  it('produces at least 200 redirects', () => {
+    assert.ok(
+      redirects.length >= 200,
+      `expected ≥200 redirects, got ${redirects.length}`,
+    );
+  });
+
+  it('every redirect is permanent (301)', () => {
+    for (const r of redirects) {
+      assert.equal(
+        r.permanent,
+        true,
+        `redirect ${r.source} → ${r.destination} must be permanent`,
+      );
+    }
+  });
+
+  it('no redirect source collides with a canonical URL', () => {
+    // The critical SEO/correctness check: if `/mp4-to-mov` were both a
+    // canonical page AND a redirect source, Next would 301-loop on the
+    // canonical page. Generator must filter these — assert it did.
+    for (const r of redirects) {
+      assert.ok(
+        !canonicalPaths.has(r.source),
+        `source ${r.source} collides with canonical URL — would shadow a real page`,
+      );
+    }
+  });
+
+  it('no canonical slug appears as a redirect source', () => {
+    // Same property phrased the way the AC asks for: walking the canonical
+    // slug set, none of those should be the source-path of any redirect.
+    const sources = new Set(redirects.map((r) => r.source));
+    for (const slug of MATRIX.map((row) => row.slug)) {
+      // Try every operation prefix — we don't know which prefix a given slug
+      // sits under without cross-referencing the matrix, so exclude all
+      // possible canonical paths instead of just "/<slug>".
+      for (const path of canonicalPaths) {
+        assert.ok(
+          !sources.has(path),
+          `canonical path ${path} (slug ${slug}) is also a redirect source`,
+        );
+      }
+    }
+  });
+
+  it('every source starts with `/` and is unique', () => {
+    const seen = new Set<string>();
+    for (const r of redirects) {
+      assert.ok(
+        r.source.startsWith('/'),
+        `source must start with /: ${r.source}`,
+      );
+      assert.ok(!seen.has(r.source), `duplicate source: ${r.source}`);
+      seen.add(r.source);
+    }
+  });
+
+  it('every destination is a canonical URL', () => {
+    for (const r of redirects) {
+      assert.ok(
+        canonicalPaths.has(r.destination),
+        `destination ${r.destination} (from ${r.source}) is not a canonical URL`,
+      );
+    }
+  });
+
+  it('emits the four misspelling patterns for a known canonical slug (mov-to-mp4)', () => {
+    // `mov-to-mp4` is a flagship page — its canonical URL is `/convert/mov-to-mp4`.
+    // We expect the four patterns: movtomp4, mov-mp4, mov_mp4, convert-mov-mp4.
+    const expected = new Set([
+      '/movtomp4',
+      '/mov-mp4',
+      '/mov_mp4',
+      '/convert-mov-mp4',
+    ]);
+    const movToMp4Redirects = redirects.filter(
+      (r) => r.destination === '/convert/mov-to-mp4',
+    );
+    const sources = new Set(movToMp4Redirects.map((r) => r.source));
+    for (const want of expected) {
+      assert.ok(
+        sources.has(want),
+        `missing misspelling source ${want} → /convert/mov-to-mp4`,
+      );
+    }
+    assert.equal(
+      movToMp4Redirects.length,
+      expected.size,
+      `expected exactly ${expected.size} redirects to /convert/mov-to-mp4, got ${movToMp4Redirects.length}`,
+    );
+  });
+
+  it('emits redirects for video-to-mp3 (extract-audio with from-to slug)', () => {
+    // `video-to-mp3` is the only extract-audio canonical slug that matches the
+    // from-to pattern (the others like `video-to-wav` do too — sanity-check the
+    // pattern generalises beyond /convert/).
+    const target = redirects.filter(
+      (r) => r.destination === '/extract-audio/video-to-mp3',
+    );
+    assert.ok(
+      target.length >= 3,
+      `expected at least 3 redirects to /extract-audio/video-to-mp3 (some patterns may collide and be filtered), got ${target.length}`,
+    );
+    const sources = new Set(target.map((r) => r.source));
+    assert.ok(
+      sources.has('/videotomp3') ||
+        sources.has('/video-mp3') ||
+        sources.has('/video_mp3'),
+      `expected at least one of /videotomp3, /video-mp3, /video_mp3 — got ${[...sources].join(', ')}`,
+    );
+  });
+});

--- a/apps/ffmpeg-converter/web/src/ops/redirects.ts
+++ b/apps/ffmpeg-converter/web/src/ops/redirects.ts
@@ -1,0 +1,150 @@
+/**
+ * SEAN-59 — 301 redirects from common slug misspellings to canonical pages.
+ *
+ * Users typo URLs all the time — "mp4tomov", "mp4-mov", "convert mp4 mov".
+ * Without redirects every typo is a 404; with them every typo lands on the
+ * canonical page and preserves SEO equity.
+ *
+ * Implemented as a pure function over the operations matrix so that adding a
+ * matrix row automatically adds the corresponding misspelling redirects. The
+ * output is consumed by `next.config.ts` `redirects()` and runs at the edge
+ * (no per-request JS).
+ *
+ * Patterns covered, for every canonical slug of shape `{from}-to-{to}`:
+ *   1. `{from}to{to}`        — no hyphens     (e.g. `mp4tomov`)
+ *   2. `{from}-{to}`         — no "to"        (e.g. `mp4-mov`)
+ *   3. `{from}_{to}`         — underscore     (e.g. `mp4_mov`)
+ *   4. `convert-{from}-{to}` — verb-flat form (e.g. `convert-mp4-mov`)
+ *
+ * Every redirect targets the nested canonical URL — `/{operation}/{slug}` for
+ * most operations, `/convert/{slug}` for `image-convert` (which lives under
+ * the `/convert` URL prefix despite being a distinct operation, mirroring the
+ * sitemap convention in `app/sitemap.ts`).
+ *
+ * IMPORTANT: a misspelling source MUST NOT collide with any canonical slug
+ * (otherwise the redirect would shadow a real page and produce a 404 loop or
+ * worse). The generator below filters collisions out and the test asserts the
+ * resulting list contains zero overlaps with the canonical slug set.
+ */
+
+import type { OperationRow } from './types';
+
+// ─────────────────────────────────────────────────────── TYPES ───────────────
+
+/**
+ * Subset of the Next.js redirect shape used by `redirects()` in next.config.ts.
+ * We only need the three fields; widening this type would just create a
+ * pointless dependency on Next's internal types in test code.
+ */
+export interface RedirectRule {
+  /** URL path to redirect FROM, e.g. `/mp4tomov`. Must start with `/`. */
+  source: string;
+  /** URL path to redirect TO, e.g. `/convert/mp4-to-mov`. Must start with `/`. */
+  destination: string;
+  /** Always `true` — every misspelling redirect is a 301. */
+  permanent: true;
+}
+
+// ─────────────────────────────────────────────────────── HELPERS ─────────────
+
+/**
+ * URL prefix for a given operation row. Mirrors the convention in
+ * `app/sitemap.ts` and the per-operation `[slug]` route folders under
+ * `src/app/[operation]/[slug]/`.
+ *
+ * `image-convert` rows live under `/convert/...` because there is no
+ * `/image-convert/...` route — they're indistinguishable from regular
+ * convert pages from a URL perspective.
+ */
+function urlPrefixFor(row: OperationRow): string {
+  return row.operation === 'image-convert' ? '/convert' : `/${row.operation}`;
+}
+
+/**
+ * Pull the `(from, to)` pair out of a `{from}-to-{to}` slug. Returns null for
+ * slugs that don't match the pattern (e.g. `compress-mp4`, `trim-mp4`,
+ * `compress-mp4-under-25mb`) — those operations don't have the from-to shape
+ * the misspelling patterns target.
+ *
+ * Matches greedy on the first `-to-` so multi-segment formats with hyphens
+ * (we have none currently, but `webp-anim` is in the type space) would still
+ * resolve correctly.
+ */
+function parseFromToSlug(slug: string): { from: string; to: string } | null {
+  const match = slug.match(/^([a-z0-9]+)-to-([a-z0-9-]+)$/);
+  if (!match) return null;
+  return { from: match[1], to: match[2] };
+}
+
+/**
+ * Generate the four misspelling source paths for one `{from}-to-{to}` slug.
+ * Returned strings include the leading `/` to match `RedirectRule.source`.
+ *
+ * Listed in matrix order so the test's "≥200 redirects" assertion has a
+ * stable count to reason about (currently 4 × N canonical from-to slugs).
+ */
+function misspellingSourcesFor(from: string, to: string): string[] {
+  return [
+    `/${from}to${to}`, // mp4tomov
+    `/${from}-${to}`, // mp4-mov
+    `/${from}_${to}`, // mp4_mov
+    `/convert-${from}-${to}`, // convert-mp4-mov
+  ];
+}
+
+// ─────────────────────────────────────────────────────── GENERATOR ───────────
+
+/**
+ * Build the full redirect list from the matrix. Pure function — no side
+ * effects, no I/O. Safe to call from `next.config.ts` (runs once at build
+ * time) or from tests.
+ *
+ * Filters:
+ *   - rows whose slug isn't `{from}-to-{to}` are skipped (no misspelling
+ *     pattern applies — e.g. `compress-mp4`, `trim-mp4`, `normalize-audio`)
+ *   - any source path that collides with a canonical URL `/{op}/{slug}` is
+ *     dropped so we never shadow a real page
+ *   - duplicate sources (could happen if two rows generated the same
+ *     misspelling) are dropped — first-write wins, since `redirects()`
+ *     ignores trailing duplicates anyway
+ */
+export function generateRedirects(rows: OperationRow[]): RedirectRule[] {
+  // Set of canonical URL paths — sources must not collide with these.
+  const canonicalPaths = new Set<string>();
+  for (const row of rows) {
+    canonicalPaths.add(`${urlPrefixFor(row)}/${row.slug}`);
+  }
+
+  const seenSources = new Set<string>();
+  const redirects: RedirectRule[] = [];
+
+  for (const row of rows) {
+    const parsed = parseFromToSlug(row.slug);
+    if (!parsed) continue; // skip non-from-to slugs
+
+    const destination = `${urlPrefixFor(row)}/${row.slug}`;
+    const sources = misspellingSourcesFor(parsed.from, parsed.to);
+
+    for (const source of sources) {
+      if (seenSources.has(source)) continue;
+      if (canonicalPaths.has(source)) continue; // never shadow a real page
+      seenSources.add(source);
+      redirects.push({ source, destination, permanent: true });
+    }
+  }
+
+  return redirects;
+}
+
+/**
+ * Expose the canonical-path set so the test can assert no source collides
+ * with any of them. Re-derives the set rather than caching it — keeps the
+ * module stateless.
+ */
+export function canonicalPathsForTest(rows: OperationRow[]): Set<string> {
+  const set = new Set<string>();
+  for (const row of rows) {
+    set.add(`${urlPrefixFor(row)}/${row.slug}`);
+  }
+  return set;
+}


### PR DESCRIPTION
Closes #59

## Summary

- Adds `src/ops/redirects.ts` — pure generator that walks the operations matrix and emits 301 redirects for each `{from}-to-{to}` canonical slug
- Patterns: `{from}to{to}`, `{from}-{to}`, `{from}_{to}`, `convert-{from}-{to}` (4 per from-to slug)
- Wired into `next.config.ts` `async redirects()` — runs at the edge, no per-request JS
- Currently emits 836 redirects across the matrix; floor of 200 enforced by test
- Generator filters any source colliding with a canonical URL so we never shadow a real page

## Test plan
- [x] `yarn test:redirects` — 8 subtests, all pass
- [x] `yarn test` — full suite (27 tests across dead-links/matrix/sitemap/redirects) passes
- [x] `tsc --noEmit` clean
- [x] `biome check` clean on changed files
- [ ] Manually verify a typo URL redirects to canonical (e.g. `/mp4tomov` -> `/convert/mp4-to-mov`) on dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)