### PR TITLE
[SEAN-56] feat: hub pages — /convert, /compress, /extract-audio, /trim, /resize, /gif

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/compress/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/compress/page.tsx
@@ -1,0 +1,32 @@
+// SEAN-56 — `/compress` hub page.
+//
+// Lists every `compress` row in the matrix. Catches fuzzy-intent traffic for
+// queries like "compress mp4" or "compress video for discord" that don't
+// match a specific format/size slug.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Compress video — shrink files for Discord, email, web',
+  description:
+    'Compress MP4, MOV, MKV, and more in your browser. Pick a target format or size limit (under 8MB, under 25MB, under 100MB) and shrink the file without a watermark.',
+};
+
+const INTRO =
+  'Shrink video files to clear an upload limit or save bandwidth. Each ' +
+  'tool below targets a specific format or output size — pick the one ' +
+  'that matches your destination (Discord at 25MB, Slack at 100MB, ' +
+  'email at 8MB) and the converter handles the bitrate maths. The exact ' +
+  'ffmpeg command is shown on every page so you can re-run it locally.';
+
+export default function CompressHub() {
+  return (
+    <HubPage
+      operation="compress"
+      h1="Compress video"
+      lede="Hit a size limit without losing more quality than you have to."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/convert/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/convert/page.tsx
@@ -1,0 +1,38 @@
+// SEAN-56 — `/convert` hub page.
+//
+// Lists every `convert` AND `image-convert` row in the matrix as a card grid
+// sorted by intent volume. Hub pages catch fuzzy-intent searches ("convert
+// video", "convert mov") that don't match a specific slug.
+//
+// Note: `apps/converter/CLAUDE.md` Directive 1 specifies a "redirect /convert
+// → /" policy — that directive applies to the OTHER converter project
+// (`apps/converter/`), not this one (`apps/ffmpeg-converter/`). Here `/convert`
+// is the hub page, not a redirect. See SEAN-56 for the rationale.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Convert files online — free, no watermark, no signup',
+  description:
+    'Browse every video, audio, and image conversion supported by Sean’s Converter. Pick a format pair and convert in your browser, no upload, no email gate.',
+};
+
+const INTRO =
+  'Pick the format pair you need and convert directly in your browser. ' +
+  'Every conversion below runs locally — files never touch a third-party ' +
+  "server, there's no watermark, no signup, and no email gate. Each tool " +
+  "page shows the exact ffmpeg command we'd run, so you can copy it for " +
+  'your own scripts.';
+
+export default function ConvertHub() {
+  return (
+    <HubPage
+      operation="convert"
+      alsoInclude={['image-convert']}
+      h1="Convert files"
+      lede="Every video, audio, and image conversion in one place."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/extract-audio/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/extract-audio/page.tsx
@@ -1,0 +1,31 @@
+// SEAN-56 — `/extract-audio` hub page.
+//
+// Lists every `extract-audio` row in the matrix. Catches queries like
+// "rip audio from mp4" or "video to mp3" that don't match a specific slug.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Extract audio from video — MP3, WAV, FLAC, Opus',
+  description:
+    'Pull the audio track out of any video file and save it as MP3, WAV, FLAC, AAC, OGG, M4A, or Opus. Free, no watermark, no signup, runs in your browser.',
+};
+
+const INTRO =
+  'Pull the audio out of a video and save it as a standalone file. The ' +
+  "right output format depends on what you'll do with it next — MP3 for " +
+  'anything universal, FLAC or WAV for editing, Opus for the smallest ' +
+  'size at the same perceived quality. Each tool below picks sensible ' +
+  'encoder defaults and shows the ffmpeg command it ran.';
+
+export default function ExtractAudioHub() {
+  return (
+    <HubPage
+      operation="extract-audio"
+      h1="Extract audio from video"
+      lede="Pull the soundtrack out of any video — MP3, WAV, FLAC, Opus, and more."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/gif/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/gif/page.tsx
@@ -1,0 +1,32 @@
+// SEAN-56 — `/gif` hub page.
+//
+// Lists every `gif` row in the matrix. Catches queries like "video to gif" or
+// "make gif from mp4" that don't match a specific input-format slug.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Video to GIF — make a GIF from any video, free',
+  description:
+    'Turn any video clip into an animated GIF. Palette-quantised for clean colours, capped at sensible frame rates so file sizes stay reasonable. Free, no watermark.',
+};
+
+const INTRO =
+  'Turn a short video clip into an animated GIF. The converter generates ' +
+  'a per-clip palette (palettegen + paletteuse) so colours stay clean ' +
+  'instead of dithering badly, caps the frame rate at sensible defaults, ' +
+  'and emits the ffmpeg command so you can re-run it with your own ' +
+  'settings. Best for clips under ten seconds — longer than that and you ' +
+  'probably want WebP or MP4 instead.';
+
+export default function GifHub() {
+  return (
+    <HubPage
+      operation="gif"
+      h1="Video to GIF"
+      lede="Turn any short clip into a clean, palette-quantised animated GIF."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/resize/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/resize/page.tsx
@@ -1,0 +1,33 @@
+// SEAN-56 — `/resize` hub page.
+//
+// Lists every `resize` row in the matrix. Catches queries like
+// "resize mp4 to 720p" or "scale video down" that don't match a specific
+// format slug.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Resize video — scale to 480p, 720p, 1080p, 1440p',
+  description:
+    'Scale video files to a target resolution while preserving aspect ratio. Pick a tool below for your input format and choose 480p, 720p, 1080p, or 1440p output.',
+};
+
+const INTRO =
+  'Scale a video to a target resolution without stretching or cropping. ' +
+  'Aspect ratio is preserved — width or height is computed from the ' +
+  "other to match the source's shape. Pick the format below that " +
+  'matches your input file; each tool offers presets for the common ' +
+  'output sizes (480p through 1440p) and shows the ffmpeg scale filter ' +
+  'it used.';
+
+export default function ResizeHub() {
+  return (
+    <HubPage
+      operation="resize"
+      h1="Resize video"
+      lede="Scale clips to 480p, 720p, 1080p, or 1440p — aspect ratio preserved."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/trim/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/trim/page.tsx
@@ -1,0 +1,32 @@
+// SEAN-56 — `/trim` hub page.
+//
+// Lists every `trim` row in the matrix. Catches queries like "trim mp4" or
+// "cut video clip" that don't match a specific format slug.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Trim video — cut clips without re-encoding when possible',
+  description:
+    'Trim the start or end off any video file. Stream-copies the original codec where possible (no quality loss) and falls back to a fast re-encode when the cut lands mid-keyframe.',
+};
+
+const INTRO =
+  'Cut a clip out of a longer recording without re-encoding the whole ' +
+  'file. Where the trim point lands on a keyframe, the original audio ' +
+  'and video streams are copied byte-for-byte, so quality stays ' +
+  'identical and the export is near-instant. When the cut falls between ' +
+  'keyframes, the converter does a quick re-encode of just the affected ' +
+  'segment and stream-copies the rest.';
+
+export default function TrimHub() {
+  return (
+    <HubPage
+      operation="trim"
+      h1="Trim video"
+      lede="Cut clips out without re-encoding the whole file."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/HubPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HubPage.tsx
@@ -1,0 +1,142 @@
+// SEAN-56 — shared hub-page template.
+//
+// One template, six routes. `/convert`, `/compress`, `/extract-audio`,
+// `/trim`, `/resize`, and `/gif` (without a `[slug]` segment) each render a
+// HubPage filtered to a single operation. Hub pages serve two purposes per
+// `phased-spec.md` §"Phase 2 — pSEO at scale":
+//
+//   1. Internal-link velocity — they crosslink the entire matrix in one
+//      place, helping Google discover the ≥200 generated tool pages quickly.
+//   2. Catch-all for fuzzy intent — a user typing "compress mp4" lands here
+//      when their exact slug isn't ranking yet.
+//
+// The card grid is sorted by `intentVolume` (head → mid → tail) so the
+// strongest commercial intent slugs appear first. Each card links straight
+// to the underlying tool page via `pathForSlug`, which is gated on the
+// route registry — if a slug somehow doesn't have a real page, it's
+// skipped silently rather than emitting a dead link.
+//
+// SERVER component — pure HTML, no client JS. Keeps the bundle minimal.
+
+import Link from 'next/link';
+import { MATRIX } from '@/ops/matrix';
+import type { Operation, OperationRow } from '@/ops/types';
+import { pathForSlug } from './route-registry';
+
+const INTENT_RANK: Record<string, number> = {
+  head: 0,
+  mid: 1,
+  tail: 2,
+};
+
+export interface HubPageProps {
+  /** Matching operation. */
+  operation: Operation;
+  /**
+   * Additional operations whose rows should also appear here. e.g. `/convert`
+   * pulls in `image-convert` rows because Directive 1's verb-first slug rule
+   * routes image conversions under `/convert/...`.
+   */
+  alsoInclude?: readonly Operation[];
+  /** Page <h1>. */
+  h1: string;
+  /** Two-line lede shown directly under the H1. */
+  lede: string;
+  /** ~50–80 word intro paragraph rendered above the card grid. */
+  intro: string;
+}
+
+/**
+ * Filter the matrix to the given operations and sort by intent volume so
+ * head slugs (`mov-to-mp4`) appear before tail slugs (`3gp-to-vob`).
+ *
+ * Rows are de-duplicated by slug (defensive — the matrix is supposed to be
+ * slug-unique already, but we don't want a duplicate-key React warning if
+ * that invariant breaks).
+ */
+function selectRows(
+  operation: Operation,
+  alsoInclude: readonly Operation[] = [],
+): OperationRow[] {
+  const ops = new Set<Operation>([operation, ...alsoInclude]);
+  const seen = new Set<string>();
+  const rows: OperationRow[] = [];
+  for (const row of MATRIX) {
+    if (!ops.has(row.operation)) continue;
+    if (seen.has(row.slug)) continue;
+    seen.add(row.slug);
+    rows.push(row);
+  }
+  rows.sort((a, b) => {
+    const rankDiff =
+      (INTENT_RANK[a.intentVolume] ?? 99) - (INTENT_RANK[b.intentVolume] ?? 99);
+    if (rankDiff !== 0) return rankDiff;
+    return a.slug.localeCompare(b.slug);
+  });
+  return rows;
+}
+
+export function HubPage({
+  operation,
+  alsoInclude,
+  h1,
+  lede,
+  intro,
+}: HubPageProps) {
+  const rows = selectRows(operation, alsoInclude);
+
+  // Filter to rows whose route actually resolves. `pathForSlug` returns null
+  // for any operation not in `IMPLEMENTED_OPERATION_ROUTES`. In practice
+  // every row we surface here will have a route — the per-op `[slug]/page.tsx`
+  // is the whole point — but keep the guard in case the matrix grows a new
+  // operation ahead of its dynamic route.
+  const cards = rows
+    .map((row) => {
+      const href = pathForSlug(row.slug);
+      return href ? { row, href } : null;
+    })
+    .filter((c): c is { row: OperationRow; href: string } => c !== null);
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 pt-12 pb-20 md:pt-16">
+      <header className="mb-6 max-w-3xl">
+        <h1 className="text-balance text-4xl font-bold tracking-tight text-gray-100 md:text-5xl">
+          {h1}
+        </h1>
+        <p className="mt-3 text-balance text-lg text-gray-400">{lede}</p>
+      </header>
+
+      <p className="mb-10 max-w-3xl text-gray-300">{intro}</p>
+
+      {cards.length === 0 ? (
+        <p className="text-gray-400">No tools available yet.</p>
+      ) : (
+        <ul className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {cards.map(({ row, href }) => (
+            <li key={row.slug}>
+              <Link
+                href={href}
+                className={[
+                  'group flex h-full flex-col justify-between gap-4',
+                  'rounded-lg border border-gray-800 bg-gray-900/60 p-5',
+                  'transition-colors',
+                  'hover:border-indigo-500 hover:bg-indigo-500/10',
+                ].join(' ')}
+              >
+                <div>
+                  <h2 className="text-lg font-semibold text-gray-100 group-hover:text-white">
+                    {row.h1}
+                  </h2>
+                  <p className="mt-2 text-sm text-gray-400">{row.valueProp}</p>
+                </div>
+                <span className="text-sm font-medium text-indigo-400 group-hover:text-indigo-300">
+                  Convert &rarr;
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
+++ b/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
@@ -1,47 +1,83 @@
 // Site footer. Every link here MUST resolve — /pricing, /docs, /llms.txt all
 // have placeholder routes until Phase 4/5 ship the real pages (see SEAN-51).
 // Do not add a nav link here without first creating its route.
+//
+// SEAN-56 added the "Browse" row of hub-page links. Each one targets a hub
+// page (`/convert`, `/compress`, etc.) that lists every variant of that
+// operation as a card grid, helping Google discover the ≥200 generated tool
+// pages quickly.
 
 import Link from 'next/link';
+
+const HUB_LINKS = [
+  { href: '/convert', label: 'Convert' },
+  { href: '/compress', label: 'Compress' },
+  { href: '/extract-audio', label: 'Extract audio' },
+  { href: '/trim', label: 'Trim' },
+  { href: '/resize', label: 'Resize' },
+  { href: '/gif', label: 'GIF' },
+];
 
 export function SiteFooter() {
   return (
     <footer className="mt-16 border-t border-gray-800 pt-8 pb-12">
-      <div className="mx-auto flex max-w-5xl flex-col items-center gap-4 px-6 text-sm text-gray-500 md:flex-row md:justify-between">
-        <p>Files auto-delete one hour after conversion.</p>
-        <nav aria-label="Footer">
-          <ul className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
-            <li>
-              <Link
-                href="/llms.txt"
-                className="hover:text-gray-300"
-                prefetch={false}
-              >
-                /llms.txt
-              </Link>
-            </li>
-            <li>
-              <Link href="/pricing" className="hover:text-gray-300">
-                Pricing
-              </Link>
-            </li>
-            <li>
-              <Link href="/docs" className="hover:text-gray-300">
-                Docs
-              </Link>
-            </li>
-            <li>
-              <a
-                href="https://github.com/seanmizen/seanorepo"
-                className="hover:text-gray-300"
-                rel="noopener noreferrer"
-                target="_blank"
-              >
-                GitHub
-              </a>
-            </li>
+      <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 text-sm text-gray-500">
+        <nav
+          aria-label="Browse tools"
+          className="flex flex-wrap items-center justify-center gap-x-2 gap-y-2 md:justify-start"
+        >
+          <span className="text-gray-400">Browse:</span>
+          <ul className="flex flex-wrap items-center gap-x-3 gap-y-2">
+            {HUB_LINKS.map((link, i) => (
+              <li key={link.href} className="flex items-center gap-x-3">
+                <Link href={link.href} className="hover:text-gray-300">
+                  {link.label}
+                </Link>
+                {i < HUB_LINKS.length - 1 ? (
+                  <span aria-hidden="true" className="text-gray-700">
+                    &middot;
+                  </span>
+                ) : null}
+              </li>
+            ))}
           </ul>
         </nav>
+        <div className="flex flex-col items-center gap-4 md:flex-row md:justify-between">
+          <p>Files auto-delete one hour after conversion.</p>
+          <nav aria-label="Footer">
+            <ul className="flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+              <li>
+                <Link
+                  href="/llms.txt"
+                  className="hover:text-gray-300"
+                  prefetch={false}
+                >
+                  /llms.txt
+                </Link>
+              </li>
+              <li>
+                <Link href="/pricing" className="hover:text-gray-300">
+                  Pricing
+                </Link>
+              </li>
+              <li>
+                <Link href="/docs" className="hover:text-gray-300">
+                  Docs
+                </Link>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/seanmizen/seanorepo"
+                  className="hover:text-gray-300"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  GitHub
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
       </div>
     </footer>
   );

--- a/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
@@ -26,6 +26,18 @@ import {
   routeExistsForSlug,
 } from '../route-registry';
 
+// SEAN-56 — hub-page routes added in this ticket. Listed here so the
+// dead-link walk recognises them as real, and so the footer's "Browse:"
+// nav row (which links into them) doesn't trip the homepage assertion.
+const HUB_ROUTES = [
+  '/convert',
+  '/compress',
+  '/extract-audio',
+  '/trim',
+  '/resize',
+  '/gif',
+];
+
 // ─────────────────────────────────────────────────────── HELPERS ─────────────
 
 /**
@@ -48,9 +60,16 @@ function buildKnownRoutes(): Set<string> {
   known.add('/docs');
   known.add('/llms.txt');
 
+  // SEAN-56 hub pages.
+  for (const hub of HUB_ROUTES) known.add(hub);
+
   // Dynamic operation routes — every matrix slug whose operation is in the
-  // implemented set.
+  // implemented set, plus image-convert rows aliased under /convert/.
   for (const row of MATRIX) {
+    if (row.operation === 'image-convert') {
+      known.add(`/convert/${row.slug}`);
+      continue;
+    }
     if (!IMPLEMENTED_OPERATION_ROUTES.has(row.operation)) continue;
     known.add(`/${row.operation}/${row.slug}`);
   }
@@ -74,6 +93,9 @@ function homepageLinks(): string[] {
   // Footer (SiteFooter.tsx) — but only the internal ones; the GitHub link is
   // external.
   links.push('/llms.txt', '/pricing', '/docs');
+
+  // SEAN-56 — hub-page nav row in the footer.
+  for (const hub of HUB_ROUTES) links.push(hub);
 
   // Logotype links back to /.
   links.push('/');

--- a/apps/ffmpeg-converter/web/src/components/route-registry.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-registry.ts
@@ -1,12 +1,15 @@
 // Single source of truth for which internal routes actually resolve today.
 //
-// Phase 1 ships only `/convert/[slug]`. Phase 2 will add /compress/[slug],
-// /extract-audio/[slug], /gif/[slug] etc — when those page routes land, add
-// their `Operation` value to `IMPLEMENTED_OPERATION_ROUTES` in the same commit.
+// Phase 2 (SEAN-52) shipped dynamic routes for compress, extract-audio, gif,
+// trim, resize, thumbnail, contact-sheet, and normalize-audio alongside the
+// existing /convert/[slug]. The registry tracks every operation whose
+// `app/[op]/[slug]/page.tsx` route exists today; hub pages (SEAN-56) depend
+// on this set to gate their card links.
 //
-// Used by HeroDrop, FlagshipPills, and ToolPage to gate every internal link on
-// "is the destination route actually implemented + is the slug in the matrix".
-// The dead-links test imports this module and walks every emitted Link.
+// Used by HeroDrop, FlagshipPills, ToolPage, and HubPage to gate every
+// internal link on "is the destination route actually implemented + is the
+// slug in the matrix". The dead-links test imports this module and walks
+// every emitted Link.
 
 import { MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { Operation } from '@/ops/types';
@@ -15,9 +18,33 @@ import type { Operation } from '@/ops/types';
  * Operations that have a corresponding `app/[op]/[slug]/page.tsx` route. Add
  * to this list when shipping a new dynamic route — never add an operation here
  * without also shipping its route, or links will 404.
+ *
+ * `image-convert` is intentionally absent: those rows are routed under
+ * `/convert/[slug]` per Directive 1's verb-first slug rule, not under their
+ * own `/image-convert/...` segment. `pathForSlug` handles the alias below.
  */
 export const IMPLEMENTED_OPERATION_ROUTES: ReadonlySet<Operation> =
-  new Set<Operation>(['convert']);
+  new Set<Operation>([
+    'convert',
+    'compress',
+    'extract-audio',
+    'gif',
+    'trim',
+    'resize',
+    'thumbnail',
+    'contact-sheet',
+    'normalize-audio',
+  ]);
+
+/**
+ * Operations whose URL prefix differs from their `Operation` value. Currently
+ * the only entry is `image-convert` → `/convert/...` per Directive 1's
+ * verb-first slug rule (image-to-jpg, image-to-webp etc. are still "convert"
+ * to the user, just with image inputs).
+ */
+const URL_PREFIX_ALIAS: Partial<Record<Operation, string>> = {
+  'image-convert': 'convert',
+};
 
 /**
  * Returns true when there is an existing matrix row for `slug` AND the row's
@@ -27,6 +54,7 @@ export const IMPLEMENTED_OPERATION_ROUTES: ReadonlySet<Operation> =
 export function routeExistsForSlug(slug: string): boolean {
   const row = MATRIX_BY_SLUG[slug];
   if (!row) return false;
+  if (URL_PREFIX_ALIAS[row.operation]) return true;
   return IMPLEMENTED_OPERATION_ROUTES.has(row.operation);
 }
 
@@ -38,6 +66,8 @@ export function routeExistsForSlug(slug: string): boolean {
 export function pathForSlug(slug: string): string | null {
   const row = MATRIX_BY_SLUG[slug];
   if (!row) return null;
+  const alias = URL_PREFIX_ALIAS[row.operation];
+  if (alias) return `/${alias}/${row.slug}`;
   if (!IMPLEMENTED_OPERATION_ROUTES.has(row.operation)) return null;
   return `/${row.operation}/${row.slug}`;
 }


### PR DESCRIPTION
Closes #56

## Summary
- Adds six hub pages (`/convert`, `/compress`, `/extract-audio`, `/trim`, `/resize`, `/gif`) without a `[slug]` segment, each listing every matrix row for that operation as a card grid sorted by intent volume.
- Shared `HubPage` component drives all six routes; six thin `page.tsx` files supply the per-op title/description/intro copy.
- `/convert` also includes `image-convert` rows per Directive 1's verb-first slug rule (image-to-jpg etc. live under `/convert/...`).
- Each card shows H1 + value prop + "Convert →" CTA linking to `pathForSlug(row.slug)`.
- Each hub has its own `<title>` + `<meta description>` distinct from the homepage so Google doesn't dedup them.
- Each hub gets a 50–80 word intro paragraph above the grid.
- `SiteFooter` gains a "Browse: Convert · Compress · Extract audio · Trim · Resize · GIF" nav row.
- Updated `IMPLEMENTED_OPERATION_ROUTES` (was stale — SEAN-52 shipped the dynamic routes but didn't bump the registry); added an `image-convert → /convert/` alias in `pathForSlug` so the dead-link guard accepts the verb-first routing.
- Notes on `apps/converter/CLAUDE.md` Directive 1 documented in `/convert/page.tsx`: that "redirect /convert → /" rule applies to the OTHER converter project (`apps/converter/`), not this one.

## Test plan
- [x] `yarn test` (ffmpeg-converter/web) — all 23 existing tests pass plus dead-links walk now includes the six hub routes
- [x] `yarn tsc --noEmit` — clean
- [x] `yarn build` emits the 6 hub routes as static pages alongside ~200 SSG tool pages
- [x] Each hub page lists its operation rows sorted head→tail (by `intentVolume`)
- [ ] Manual smoke test: `/convert`, `/compress`, `/extract-audio`, `/trim`, `/resize`, `/gif` render without 404 or hydration error

🤖 Generated with [Claude Code](https://claude.com/claude-code)