### PR TITLE
[SEAN-77] fix: video-to-ogg / video-to-wav routed to dedicated codec ops

### DIFF
--- a/apps/ffmpeg-converter/e2e_test.go
+++ b/apps/ffmpeg-converter/e2e_test.go
@@ -672,6 +672,195 @@ func TestConvert_RealFfmpeg_SpacedFilename_WebP(t *testing.T) {
 	}
 }
 
+// TestConvert_RealFfmpeg_ExtractAudio_WavCodec verifies that the extract_audio
+// op produces a real WAV file (RIFF header) with stereo source preserved as
+// stereo and CD-quality sample rate (44.1 kHz). Regression test for the bug
+// where extract_audio hard-coded -ar 16000 -ac 1, downgrading music sources
+// to transcription quality.
+func TestConvert_RealFfmpeg_ExtractAudio_WavCodec(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not on PATH")
+	}
+	ffprobePath, ffprobeErr := exec.LookPath("ffprobe")
+	if ffprobeErr != nil {
+		t.Skip("ffprobe not on PATH – needed to verify codec/rate/channels")
+	}
+
+	ts := newCoreServer(t)
+
+	// Generate a 1-second stereo 44.1 kHz video as input. extract_audio must
+	// preserve those characteristics on the way out.
+	tmpDir := t.TempDir()
+	inputPath := tmpDir + "/input.mp4"
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "color=c=blue:s=64x36:r=10:d=1",
+		"-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100:duration=1",
+		"-ac", "2",
+		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "40",
+		"-c:a", "aac", "-b:a", "96k",
+		"-shortest", inputPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not generate test video: %v\n%s", err, out)
+	}
+	inputData, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+
+	code, body := doConvert(t, ts, "extract_audio",
+		map[string][]byte{"input.mp4": inputData}, nil, "")
+	if code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body: %s", code, body)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(body, &resp)
+	if resp["status"] != "done" {
+		t.Errorf("want status=done, got %v", resp["status"])
+	}
+
+	// Pull the WAV bytes back and write to disk so ffprobe can inspect.
+	dlResp, err := http.Get(ts.URL + resp["output"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dlResp.Body.Close()
+	wavBytes, _ := io.ReadAll(dlResp.Body)
+	if len(wavBytes) < 44 {
+		t.Fatalf("output too small to be a WAV (%d bytes)", len(wavBytes))
+	}
+	// RIFF/WAVE header sanity check: bytes [0:4]="RIFF", [8:12]="WAVE".
+	if !bytes.Equal(wavBytes[0:4], []byte("RIFF")) || !bytes.Equal(wavBytes[8:12], []byte("WAVE")) {
+		t.Fatalf("output is not a RIFF/WAVE file: header=%q", wavBytes[0:12])
+	}
+	wavPath := tmpDir + "/output.wav"
+	if err := os.WriteFile(wavPath, wavBytes, 0o644); err != nil {
+		t.Fatalf("write wav: %v", err)
+	}
+
+	// ffprobe → JSON, check codec_name=pcm_s16le, sample_rate=44100, channels=2.
+	probe := exec.Command(ffprobePath,
+		"-v", "error", "-select_streams", "a:0",
+		"-show_entries", "stream=codec_name,sample_rate,channels",
+		"-of", "json", wavPath)
+	probeOut, err := probe.Output()
+	if err != nil {
+		t.Fatalf("ffprobe failed: %v", err)
+	}
+	var probed struct {
+		Streams []struct {
+			CodecName  string `json:"codec_name"`
+			SampleRate string `json:"sample_rate"`
+			Channels   int    `json:"channels"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(probeOut, &probed); err != nil {
+		t.Fatalf("parse ffprobe output: %v", err)
+	}
+	if len(probed.Streams) == 0 {
+		t.Fatalf("ffprobe found no audio stream in output")
+	}
+	s := probed.Streams[0]
+	if s.CodecName != "pcm_s16le" {
+		t.Errorf("want codec_name=pcm_s16le, got %q", s.CodecName)
+	}
+	if s.SampleRate != "44100" {
+		t.Errorf("want sample_rate=44100 (mirroring source), got %q", s.SampleRate)
+	}
+	if s.Channels != 2 {
+		t.Errorf("want channels=2 (stereo, mirroring source), got %d", s.Channels)
+	}
+}
+
+// TestConvert_RealFfmpeg_AudioOgg_VorbisCodec verifies that the audio_ogg op
+// produces a real Vorbis-in-Ogg file. Regression test for the bug where the
+// matrix routed video-to-ogg at extract_audio (which produced WAV bytes inside
+// a .ogg-named file).
+func TestConvert_RealFfmpeg_AudioOgg_VorbisCodec(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not on PATH")
+	}
+	ffprobePath, ffprobeErr := exec.LookPath("ffprobe")
+	if ffprobeErr != nil {
+		t.Skip("ffprobe not on PATH – needed to verify codec")
+	}
+	encoders, _ := exec.Command("ffmpeg", "-hide_banner", "-encoders").Output()
+	if !strings.Contains(string(encoders), "libvorbis") {
+		t.Skip("libvorbis encoder not built into ffmpeg")
+	}
+
+	ts := newCoreServer(t)
+
+	tmpDir := t.TempDir()
+	inputPath := tmpDir + "/input.mp4"
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "color=c=blue:s=64x36:r=10:d=1",
+		"-f", "lavfi", "-i", "sine=frequency=440:sample_rate=44100:duration=1",
+		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "40",
+		"-c:a", "aac", "-b:a", "96k",
+		"-shortest", inputPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not generate test video: %v\n%s", err, out)
+	}
+	inputData, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+
+	code, body := doConvert(t, ts, "audio_ogg",
+		map[string][]byte{"input.mp4": inputData}, nil, "")
+	if code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body: %s", code, body)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(body, &resp)
+	if resp["status"] != "done" {
+		t.Errorf("want status=done, got %v", resp["status"])
+	}
+
+	dlResp, err := http.Get(ts.URL + resp["output"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dlResp.Body.Close()
+	oggBytes, _ := io.ReadAll(dlResp.Body)
+	if len(oggBytes) < 4 {
+		t.Fatalf("output too small (%d bytes)", len(oggBytes))
+	}
+	// Ogg files start with "OggS" capture pattern (RFC 3533, §6).
+	if !bytes.Equal(oggBytes[0:4], []byte("OggS")) {
+		t.Fatalf("output is not an Ogg container: header=%q (regression: backend probably emitted WAV)", oggBytes[0:min(12, len(oggBytes))])
+	}
+	oggPath := tmpDir + "/output.ogg"
+	if err := os.WriteFile(oggPath, oggBytes, 0o644); err != nil {
+		t.Fatalf("write ogg: %v", err)
+	}
+
+	probe := exec.Command(ffprobePath,
+		"-v", "error", "-select_streams", "a:0",
+		"-show_entries", "stream=codec_name",
+		"-of", "json", oggPath)
+	probeOut, err := probe.Output()
+	if err != nil {
+		t.Fatalf("ffprobe failed: %v", err)
+	}
+	var probed struct {
+		Streams []struct {
+			CodecName string `json:"codec_name"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(probeOut, &probed); err != nil {
+		t.Fatalf("parse ffprobe output: %v", err)
+	}
+	if len(probed.Streams) == 0 {
+		t.Fatalf("ffprobe found no audio stream in output")
+	}
+	if probed.Streams[0].CodecName != "vorbis" {
+		t.Errorf("want codec_name=vorbis, got %q", probed.Streams[0].CodecName)
+	}
+}
+
 // ── /billing/me (billing disabled) ───────────────────────────────────────────
 
 func TestBillingMe_BillingDisabled(t *testing.T) {

--- a/apps/ffmpeg-converter/ops.go
+++ b/apps/ffmpeg-converter/ops.go
@@ -392,6 +392,15 @@ func RegisterOps() map[string]*Operation {
 		},
 	})
 	add(&Operation{
+		Name: "audio_ogg", Category: "audio",
+		Description: "Convert/extract to Ogg Vorbis",
+		DefaultExt:  ".ogg",
+		Run: func(ctx context.Context, oc OpContext) error {
+			return ffmpegRun(ctx, "-i", oc.Inputs[0],
+				"-vn", "-c:a", "libvorbis", "-q:a", "5", oc.Output)
+		},
+	})
+	add(&Operation{
 		Name: "audio_aac", Category: "audio",
 		Description: "Convert/extract to AAC (m4a)",
 		DefaultExt:  ".m4a",
@@ -411,11 +420,16 @@ func RegisterOps() map[string]*Operation {
 	})
 	add(&Operation{
 		Name: "extract_audio", Category: "audio",
-		Description: "Strip audio from a video (wav)",
+		Description: "Strip audio from a video (CD-quality WAV)",
 		DefaultExt:  ".wav",
 		Run: func(ctx context.Context, oc OpContext) error {
+			// Mirror source rate/channels by not forcing -ar/-ac. Output is
+			// CD-quality stereo WAV when the source is stereo, mono WAV when
+			// the source is mono — appropriate for music, mixing, and editing.
+			// Transcription pipelines that need 16 kHz mono should resample
+			// after the fact.
 			return ffmpegRun(ctx, "-i", oc.Inputs[0],
-				"-vn", "-acodec", "pcm_s16le", "-ar", "16000", "-ac", "1", oc.Output)
+				"-vn", "-c:a", "pcm_s16le", oc.Output)
 		},
 	})
 	add(&Operation{

--- a/apps/ffmpeg-converter/web/src/ops/matrix.ts
+++ b/apps/ffmpeg-converter/web/src/ops/matrix.ts
@@ -341,7 +341,7 @@ function extractAudioRow(audioOut: Format, goOp: GoOpName): OperationRow {
     audioOut === 'mp3'
       ? '-c:a libmp3lame -b:a 192k'
       : audioOut === 'wav'
-        ? '-acodec pcm_s16le'
+        ? '-c:a pcm_s16le'
         : audioOut === 'aac'
           ? '-c:a aac -b:a 192k'
           : audioOut === 'flac'
@@ -756,7 +756,7 @@ const CURATED_MATRIX: OperationRow[] = [
     title: 'Extract WAV from video — free, no watermark',
     h1: 'Video to WAV',
     valueProp: 'Lossless audio out. No watermark.',
-    ffmpegCommand: 'ffmpeg -i input.{ext} -vn -acodec pcm_s16le output.wav',
+    ffmpegCommand: 'ffmpeg -i input.{ext} -vn -c:a pcm_s16le output.wav',
     intentVolume: 'mid',
     faqs: [
       {
@@ -1273,7 +1273,7 @@ function generateCompressRows(): OperationRow[] {
 function generateExtractAudioRows(): OperationRow[] {
   const rows: OperationRow[] = [];
   const audioOpMap: Partial<Record<Format, GoOpName>> = {
-    ogg: 'extract_audio',
+    ogg: 'audio_ogg',
     opus: 'audio_opus',
   };
   for (const audioOut of AUDIO_OUTPUTS_EXTRACT) {

--- a/apps/ffmpeg-converter/web/src/ops/types.ts
+++ b/apps/ffmpeg-converter/web/src/ops/types.ts
@@ -192,6 +192,7 @@ export type GoOpName =
   // audio
   | 'audio_mp3'
   | 'audio_opus'
+  | 'audio_ogg'
   | 'audio_aac'
   | 'audio_flac'
   | 'extract_audio'


### PR DESCRIPTION
Closes #77

## Summary
- Adds a new `audio_ogg` op (libvorbis -q:a 5) and routes `video-to-ogg` to it, so the output is actually Vorbis-in-Ogg instead of WAV bytes in a `.ogg`-named file.
- Drops the hard-coded `-ar 16000 -ac 1` from `extract_audio` so `video-to-wav` mirrors the source rate/channels (CD-quality stereo for music).
- Updates the curated `video-to-wav` `ffmpegCommand` to match the backend.
- Adds two e2e tests asserting output codec/rate/channels via ffprobe.

## Test plan
- [x] `cd apps/ffmpeg-converter && go build ./...`
- [x] `cd apps/ffmpeg-converter && go test ./...` (all tests pass; ogg test skipped locally without libvorbis but runs on prod).
- [ ] After deploy: `curl https://seansconverter.com/extract-audio/video-to-ogg`, drop an MP4, confirm `file output.ogg` reports `Ogg data, Vorbis`.
- [ ] After deploy: `curl https://seansconverter.com/extract-audio/video-to-wav`, drop an MP4 with stereo 44.1 kHz audio, confirm `ffprobe output.wav` reports `pcm_s16le, 44100 Hz, stereo`.