### PR TITLE
[SEAN-82] chore: remove dead /pricing and /docs nav links

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/docs/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/docs/page.tsx
@@ -1,7 +1,7 @@
 // Phase 4/5 placeholder. The real /docs surface — /docs/api (Phase 4) and
-// /docs/mcp (Phase 5) — ships with the API tier and MCP server. This stub
-// exists so the header & footer Docs link doesn't 404 in the meantime.
-// Do NOT remove the route without also removing the nav links — see SEAN-51.
+// /docs/mcp (Phase 5) — ships with the API tier and MCP server. The header
+// & footer Docs nav links were removed in SEAN-82 — this stub now only covers
+// direct/bookmarked URLs so they don't 404 until Phase 4/5 ships.
 
 import type { Metadata } from 'next';
 import Link from 'next/link';

--- a/apps/ffmpeg-converter/web/src/app/layout.tsx
+++ b/apps/ffmpeg-converter/web/src/app/layout.tsx
@@ -25,23 +25,10 @@ export default function RootLayout({
             >
               Sean&apos;s Converter
             </Link>
-            {/* /pricing and /docs are placeholder routes until Phase 4 ships
-                the real pages — see SEAN-51. Do not add a nav link here
-                without first creating its route. */}
-            <nav aria-label="Primary">
-              <ul className="flex items-center gap-5 text-sm text-gray-400">
-                <li>
-                  <Link href="/pricing" className="hover:text-gray-100">
-                    Pricing
-                  </Link>
-                </li>
-                <li>
-                  <Link href="/docs" className="hover:text-gray-100">
-                    Docs
-                  </Link>
-                </li>
-              </ul>
-            </nav>
+            {/* SEAN-82 — Pricing/Docs nav links removed until Phase 4 ships the
+                real pages. The conversion funnel is the homepage drop-zone;
+                routing users to placeholder pages is pure friction. Re-add a
+                primary nav once /pricing and /docs have content worth visiting. */}
           </div>
         </header>
 

--- a/apps/ffmpeg-converter/web/src/app/pricing/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/pricing/page.tsx
@@ -1,7 +1,7 @@
 // Phase 4 placeholder. The real /pricing page (three columns: Free / Pro £10/mo
-// / API metered, per phased-spec.md §"Phase 4") ships with the API tier. This
-// stub exists so the header & footer Pricing link doesn't 404 in the meantime.
-// Do NOT remove the route without also removing the nav links — see SEAN-51.
+// / API metered, per phased-spec.md §"Phase 4") ships with the API tier. The
+// header & footer Pricing nav links were removed in SEAN-82 — this stub now
+// only covers direct/bookmarked URLs so they don't 404 until Phase 4 ships.
 
 import type { Metadata } from 'next';
 import Link from 'next/link';

--- a/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
+++ b/apps/ffmpeg-converter/web/src/components/SiteFooter.tsx
@@ -1,6 +1,8 @@
-// Site footer. Every link here MUST resolve — /pricing, /docs, /llms.txt all
-// have placeholder routes until Phase 4/5 ship the real pages (see SEAN-51).
-// Do not add a nav link here without first creating its route.
+// Site footer. Every link here MUST resolve. /llms.txt is a real route; the
+// hub-page links target real generated routes (SEAN-56). The /pricing and
+// /docs placeholder links were removed in SEAN-82 — they pointed at empty
+// stubs and were pure funnel friction. Re-add them once Phase 4 ships real
+// content.
 //
 // SEAN-56 added the "Browse" row of hub-page links. Each one targets a hub
 // page (`/convert`, `/compress`, etc.) that lists every variant of that
@@ -53,16 +55,6 @@ export function SiteFooter() {
                   prefetch={false}
                 >
                   /llms.txt
-                </Link>
-              </li>
-              <li>
-                <Link href="/pricing" className="hover:text-gray-300">
-                  Pricing
-                </Link>
-              </li>
-              <li>
-                <Link href="/docs" className="hover:text-gray-300">
-                  Docs
                 </Link>
               </li>
               <li>

--- a/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
@@ -53,9 +53,10 @@ function buildKnownRoutes(): Set<string> {
   // Static routes (top-level pages).
   known.add('/');
 
-  // Footer/header links handled by SEAN-51 — listed here so the homepage walk
-  // doesn't false-flag them. They are static stubs (or external in the case of
-  // the GitHub link), not 404s.
+  // /pricing and /docs are still real (placeholder) routes — kept so that
+  // bookmarked/external links don't 404 — but as of SEAN-82 they are no longer
+  // linked from the header or footer (the dead-end nav links were pure funnel
+  // friction). Listed here because the file-system route still exists.
   known.add('/pricing');
   known.add('/docs');
   known.add('/llms.txt');
@@ -87,12 +88,12 @@ function buildKnownRoutes(): Set<string> {
 function homepageLinks(): string[] {
   const links: string[] = [];
 
-  // Header (layout.tsx).
-  links.push('/pricing', '/docs');
+  // Header (layout.tsx) — no nav links anymore (SEAN-82); only the logotype,
+  // pushed below.
 
-  // Footer (SiteFooter.tsx) — but only the internal ones; the GitHub link is
-  // external.
-  links.push('/llms.txt', '/pricing', '/docs');
+  // Footer (SiteFooter.tsx) — only /llms.txt remains as an internal link
+  // (Pricing/Docs removed in SEAN-82); the GitHub link is external.
+  links.push('/llms.txt');
 
   // SEAN-56 — hub-page nav row in the footer.
   for (const hub of HUB_ROUTES) links.push(hub);


### PR DESCRIPTION
Closes #82

## Decision

**Option A** — removed the nav links from header and footer. The placeholder routes (`/pricing`, `/docs`) stay so any direct/bookmarked URL still resolves, but nothing in the app surface points at them anymore. Cheapest, fastest fix; no half-baked content shipped. Re-add the nav (or replace the stubs with real one-screen pages) when Phase 4 ships actual content worth visiting.

## Summary

- Stripped `/pricing` and `/docs` from the primary nav in `app/layout.tsx` (header is now just the logotype).
- Stripped `/pricing` and `/docs` from the footer's internal-link list in `SiteFooter.tsx`. Footer now only links to `/llms.txt` and the external GitHub repo (plus the `Browse:` hub-page row added in SEAN-56).
- Kept the placeholder pages (`app/pricing/page.tsx`, `app/docs/page.tsx`) — direct URLs still resolve to a friendly stub instead of 404 — but updated their header comments to reflect the new state.
- Updated `dead-links.test.ts` to drop `/pricing` and `/docs` from the simulated homepage link surface (the `knownRoutes` set keeps them since the routes themselves still exist).

## Test plan

- [x] `yarn test:dead-links` passes (4/4)
- [x] `yarn test` (full converter web suite) passes (5/5)
- [x] `tsc --noEmit` clean for `apps/ffmpeg-converter/web`
- [x] Biome clean on the 5 modified files
- [ ] Visual smoke: load `/`, confirm header is logotype-only and footer shows just `/llms.txt` + GitHub (plus `Browse:` row)
- [ ] Visit `/pricing` and `/docs` directly — should still render the placeholder, not 404