### PR TITLE
[SEAN-75] fix: homepage upload loses file on redirect to slug page

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -13,7 +13,8 @@
     "test:sitemap": "ts-node -P tsconfig.test.json src/ops/sitemap.test.ts",
     "test:redirects": "ts-node -P tsconfig.test.json src/ops/redirects.test.ts",
     "test:word-count": "ts-node -P tsconfig.test.json src/ops/word-count.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count"
+    "test:hero-drop": "ts-node -P tsconfig.test.json src/components/__tests__/HeroDrop.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -32,6 +32,19 @@ export interface ConverterPanelProps {
   reverseLabel?: string;
   /** Operation prefix for the reverse URL. */
   reverseOperation?: string;
+  /**
+   * SEAN-75: pre-loaded file forwarded from the homepage drop zone. When set,
+   * `<DropZone />` auto-fires the upload on mount so the user reaches the
+   * converting/result UI without dropping a second time.
+   */
+  initialFile?: File;
+  /**
+   * SEAN-75: called when the user clicks "Try another file" in the result
+   * block. Lets the homepage flow tear down the embedded converter and
+   * restore the original hero drop zone, instead of leaving a slug-page-shaped
+   * panel sitting on the homepage.
+   */
+  onReset?: () => void;
 }
 
 export function ConverterPanel({
@@ -44,6 +57,8 @@ export function ConverterPanel({
   reverseSlug,
   reverseLabel,
   reverseOperation,
+  initialFile,
+  onReset,
 }: ConverterPanelProps) {
   const [job, setJob] = useState<ConversionJob | null>(null);
 
@@ -56,6 +71,7 @@ export function ConverterPanel({
         acceptLabel={acceptLabel}
         extraArgs={extraArgs}
         onJobComplete={setJob}
+        initialFile={initialFile}
       />
     );
   }
@@ -66,7 +82,10 @@ export function ConverterPanel({
       reverseSlug={reverseSlug}
       reverseLabel={reverseLabel}
       reverseOperation={reverseOperation}
-      onReset={() => setJob(null)}
+      onReset={() => {
+        setJob(null);
+        onReset?.();
+      }}
     />
   );
 }

--- a/apps/ffmpeg-converter/web/src/components/DropZone.tsx
+++ b/apps/ffmpeg-converter/web/src/components/DropZone.tsx
@@ -15,20 +15,16 @@ import {
   type DragEvent,
   type ReactNode,
   useCallback,
+  useEffect,
   useRef,
   useState,
 } from 'react';
+import { type ConversionJob, submitConversion } from './submit-conversion';
 
-export interface ConversionJob {
-  /** Backend job id, e.g. UUID. */
-  jobId: string;
-  /** Same-origin download URL (`/api/jobs/<id>/output`). */
-  downloadUrl: string;
-  /** Original input filename, used to name the downloaded result. */
-  inputFilename: string;
-  /** Output extension (without leading dot), e.g. `mp4`, `webp`, `mp3`. */
-  outputExt: string;
-}
+// Re-export the job/args types from the JSX-free module so existing imports
+// (`from './DropZone'`) keep working.
+export type { ConversionJob, SubmitConversionArgs } from './submit-conversion';
+export { submitConversion } from './submit-conversion';
 
 export interface DropZoneProps {
   /**
@@ -58,6 +54,14 @@ export interface DropZoneProps {
   header?: ReactNode;
   /** Called when the upload + conversion succeeds. */
   onJobComplete: (job: ConversionJob) => void;
+  /**
+   * SEAN-75: pre-loaded file. When provided, the drop zone immediately fires
+   * the upload on mount instead of waiting for a fresh user drop. Used by the
+   * homepage flow where the user already provided a file in the hero zone —
+   * the file is forwarded to a freshly-mounted `<DropZone />` so they don't
+   * have to drop it a second time.
+   */
+  initialFile?: File;
 }
 
 type Status = 'idle' | 'uploading' | 'converting';
@@ -70,6 +74,7 @@ export function DropZone({
   extraArgs,
   header,
   onJobComplete,
+  initialFile,
 }: DropZoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -83,38 +88,15 @@ export function DropZone({
       setStatus('uploading');
       setPendingName(file.name);
 
-      const form = new FormData();
-      form.append('op', goOp);
-      form.append('file', file);
-      form.append('ext', outputExt);
-      if (extraArgs) {
-        for (const [k, v] of Object.entries(extraArgs)) {
-          if (v !== '') form.append(k, v);
-        }
-      }
-
       try {
         setStatus('converting');
-        const res = await fetch('/api/convert', {
-          method: 'POST',
-          body: form,
-        });
-        if (!res.ok) {
-          const text = await res.text();
-          throw new Error(text || `${res.status} ${res.statusText}`);
-        }
-        const data = (await res.json()) as {
-          job_id?: string;
-          output?: string;
-        };
-        const jobId = data.job_id ?? '';
-        const downloadPath = data.output ?? `/jobs/${jobId}/output`;
-        onJobComplete({
-          jobId,
-          downloadUrl: `/api${downloadPath}`,
-          inputFilename: file.name,
+        const job = await submitConversion({
+          file,
+          goOp,
           outputExt,
+          extraArgs,
         });
+        onJobComplete(job);
         setStatus('idle');
         setPendingName(null);
       } catch (e) {
@@ -130,6 +112,20 @@ export function DropZone({
   const handleFile = (file: File) => {
     void runConversion(file);
   };
+
+  // SEAN-75: when the homepage hands us a pre-dropped file, fire the upload
+  // immediately on mount so the user doesn't have to interact a second time.
+  // Each `initialFile` is auto-submitted exactly once — subsequent renders
+  // (parent re-render, status changes) don't re-fire because we key on the
+  // File object reference.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: runConversion
+  // captures props that mutate per-render; we want to fire only when the
+  // initialFile reference changes, not when callbacks rebuild.
+  useEffect(() => {
+    if (initialFile) {
+      void runConversion(initialFile);
+    }
+  }, [initialFile]);
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -1,29 +1,51 @@
 'use client';
 
-// Above-the-fold drop zone. Detects file type on drop / select and routes to
-// the canonical tool page (e.g. .mov → /convert/mov-to-mp4). Acts as the
-// homepage's primary CTA.
+// Above-the-fold homepage drop zone.
 //
-// Routing-only in Phase 1 — actual conversion happens on the destination tool
-// page (Phase 2). We don't try to start the upload here because the tool page
-// owns the conversion UI and result block.
+// SEAN-75: dropping a file used to immediately `router.push()` to the slug
+// page — but the `File` object lived in this component's memory and never
+// made it to the destination, so the user had to drop it a second time. The
+// cancellation rate at that step was the central UX failure of the funnel.
+//
+// New behaviour (Option A — KISS): the homepage runs the conversion in
+// place. We pick the matrix row using the same preference table as the old
+// `routeForFile`, mount the same `<ConverterPanel />` the slug pages use, and
+// hand it the dropped File via `initialFile` so it auto-fires the upload on
+// mount. No navigation, no lost File, one drop.
+//
+// SEO is unaffected: someone landing on `/convert/mov-to-mp4` directly from
+// Google still gets the slug page with its input-locked drop zone — those
+// pages are unchanged.
 
-import { useRouter } from 'next/navigation';
 import { type DragEvent, useRef, useState } from 'react';
-import { extOf, routeForFile } from './route-for-file';
+import { ConverterPanel } from './ConverterPanel';
+import {
+  buildAcceptLabel,
+  buildAcceptString,
+  buildExtraArgs,
+  findReverse,
+  formatToExt,
+} from './converter-row-args';
+import { extOf, type MatrixRowMatch, matrixRowForFile } from './route-for-file';
+
+interface ActiveJob {
+  file: File;
+  match: MatrixRowMatch;
+}
 
 export function HeroDrop() {
-  const router = useRouter();
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [active, setActive] = useState<ActiveJob | null>(null);
 
   const handleFile = (file: File) => {
-    // SEAN-50: routeForFile only returns paths that resolve to a real route
-    // (matrix slug + implemented operation). Anything else falls through to
-    // the friendly error rather than routing the user to a 404.
-    const target = routeForFile(file);
-    if (!target) {
+    // SEAN-50 / SEAN-75: matrixRowForFile only resolves to rows whose
+    // operation route is actually implemented (matrix slug + registry gate).
+    // Anything else surfaces the friendly error — we don't drop the user
+    // into a converter panel for an op we can't run.
+    const match = matrixRowForFile(file);
+    if (!match) {
       const ext = extOf(file.name);
       setError(
         ext
@@ -33,7 +55,7 @@ export function HeroDrop() {
       return;
     }
     setError(null);
-    router.push(target);
+    setActive({ file, match });
   };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
@@ -51,6 +73,32 @@ export function HeroDrop() {
   const handleDragLeave = () => setDragOver(false);
 
   const handleClick = () => inputRef.current?.click();
+
+  // Conversion in flight (or done) — render the same ConverterPanel the slug
+  // pages use, with the file pre-loaded so the upload auto-fires on mount.
+  if (active) {
+    const { row } = active.match;
+    const reverse = findReverse(row);
+    return (
+      <ConverterPanel
+        goOp={row.goOp}
+        outputExt={formatToExt(row.outputFormat)}
+        accept={buildAcceptString(row)}
+        acceptLabel={buildAcceptLabel(row)}
+        extraArgs={buildExtraArgs(row)}
+        ffmpegCommand={row.ffmpegCommand}
+        reverseSlug={reverse?.slug}
+        reverseLabel={reverse?.label}
+        reverseOperation={reverse?.operation}
+        initialFile={active.file}
+        // SEAN-75: "Try another file" on the homepage tears the converter
+        // back down to the original hero drop zone, so the user lands on a
+        // clean, recognisable homepage state instead of an empty slug-shaped
+        // panel.
+        onReset={() => setActive(null)}
+      />
+    );
+  }
 
   return (
     <div className="w-full">

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -24,12 +24,18 @@
 import Link from 'next/link';
 import { buildToolPageSchemas } from '@/lib/schemas';
 import { resolvePageCopy } from '@/ops/copy';
-import { MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { OperationRow, ResolvedPage } from '@/ops/types';
 import { ConverterPanel } from './ConverterPanel';
+import {
+  buildAcceptLabel,
+  buildAcceptString,
+  buildExtraArgs,
+  findReverse,
+  formatToExt,
+  resolveSiblings,
+} from './converter-row-args';
 import { FAQ } from './FAQ';
 import { JsonLd } from './JsonLd';
-import { pathForSlug, routeExistsForSlug } from './route-registry';
 
 export interface ToolPageProps {
   row: OperationRow;
@@ -82,7 +88,7 @@ export function ToolPage({ row, page }: ToolPageProps) {
       <section className="mb-10" aria-label="Convert your file">
         <ConverterPanel
           goOp={row.goOp}
-          outputExt={extOf(row.outputFormat)}
+          outputExt={formatToExt(row.outputFormat)}
           accept={accept}
           acceptLabel={acceptLabel}
           extraArgs={extraArgs}
@@ -198,116 +204,5 @@ function HowItWorks({
   );
 }
 
-// ─────────────────────────────────────────────────────── HELPERS ─────────────
-
-/**
- * Map a Format enum to the file extension used in URLs and filenames. Most
- * formats are their own extension; the special-cases below cover the ones
- * with longer names.
- */
-function extOf(format: string): string {
-  switch (format) {
-    case 'gif-static':
-      return 'gif';
-    case 'webp-anim':
-      return 'webp';
-    default:
-      return format;
-  }
-}
-
-/**
- * Build the `<input accept>` attribute from the row's accepted input formats.
- * Each format maps to its `.ext` form; we don't bother with MIME types since
- * the backend validates anyway.
- */
-function buildAcceptString(row: OperationRow): string {
-  return row.inputFormats.map((f) => `.${extOf(f)}`).join(',');
-}
-
-/**
- * Human-readable accept label for the drop zone copy. Single format → just
- * the name (`MOV`); 2-3 formats → all listed; many formats → "video file" etc.
- */
-function buildAcceptLabel(row: OperationRow): string {
-  if (row.inputFormats.length === 0) return 'file';
-  if (row.inputFormats.length === 1) {
-    return extOf(row.inputFormats[0] ?? '').toUpperCase();
-  }
-  if (row.inputFormats.length <= 3) {
-    return row.inputFormats.map((f) => extOf(f).toUpperCase()).join(', ');
-  }
-  // Many inputs — group by media kind for the copy.
-  return 'video file';
-}
-
-/**
- * Build the `extraArgs` map forwarded to the Go op. Pulls preset hints from
- * the row (CRF, target size, FPS, etc.) — the backend reads them from the
- * multipart form values.
- */
-function buildExtraArgs(row: OperationRow): Record<string, string> | undefined {
-  const args: Record<string, string> = {};
-  const p = row.preset;
-  if (!p) return undefined;
-  if (p.crf !== undefined) args.crf = String(p.crf);
-  if (p.preset !== undefined) args.preset = p.preset;
-  if (p.targetSizeMb !== undefined) {
-    args.target_size_mb = String(p.targetSizeMb);
-  }
-  if (p.resolution !== undefined) args.resolution = p.resolution;
-  if (p.fps !== undefined) args.fps = String(p.fps);
-  if (p.audioBitrate !== undefined) args.audio_bitrate = p.audioBitrate;
-  return Object.keys(args).length > 0 ? args : undefined;
-}
-
-interface SiblingLink {
-  slug: string;
-  label: string;
-  href: string;
-}
-
-/**
- * Resolve `row.related` slugs against the matrix.
- *
- * SEAN-50: every sibling must be (a) present in `MATRIX_BY_SLUG` and (b) have
- * an implemented operation route. Slugs that fail either gate are dropped
- * rather than rendered as 404 links. The visible "Related" section hides
- * itself when the filter empties the list.
- */
-function resolveSiblings(row: OperationRow): SiblingLink[] {
-  const out: SiblingLink[] = [];
-  for (const slug of row.related ?? []) {
-    const sib = MATRIX_BY_SLUG[slug];
-    if (!sib) continue;
-    if (!routeExistsForSlug(slug)) continue;
-    const href = pathForSlug(slug);
-    if (!href) continue;
-    out.push({ slug, label: sib.h1, href });
-  }
-  return out;
-}
-
-/**
- * Find the inverse-direction row (e.g. `mov-to-mp4` → `mp4-to-mov`). Only
- * applies to two-format `convert` rows whose reverse slug is in the matrix
- * AND whose route is implemented. Returns null otherwise — the converter
- * panel hides the reverse-link CTA when this is null.
- */
-function findReverse(
-  row: OperationRow,
-): { slug: string; label: string; operation: string } | null {
-  if (row.operation !== 'convert') return null;
-  if (row.inputFormats.length !== 1) return null;
-  const inputExt = extOf(row.inputFormats[0] ?? '');
-  const outputExt = extOf(row.outputFormat);
-  const reverseSlug = `${outputExt}-to-${inputExt}`;
-  const sib = MATRIX_BY_SLUG[reverseSlug];
-  if (!sib) return null;
-  if (!routeExistsForSlug(reverseSlug)) return null;
-  return {
-    slug: sib.slug,
-    label: sib.h1,
-    operation: sib.operation,
-  };
-}
+// Row → ConverterPanel-args mapping helpers live in `./converter-row-args.ts`
+// so the homepage `<HeroDrop />` flow (SEAN-75) reuses the same logic.

--- a/apps/ffmpeg-converter/web/src/components/__tests__/HeroDrop.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/HeroDrop.test.ts
@@ -1,0 +1,175 @@
+/**
+ * SEAN-75 — homepage drop must not lose the File.
+ *
+ * Reproduces the bug from the ticket: the user drops a `.mov` on the
+ * homepage drop zone and previously got `router.push()`-ed to
+ * `/convert/mov-to-mp4` with their File abandoned in the homepage's component
+ * memory. The fix routes the homepage drop into the same `<ConverterPanel />`
+ * the slug pages use, with the File pre-loaded so the upload auto-fires.
+ *
+ * This test drives the load-bearing path of that fix:
+ *   1. `matrixRowForFile()` resolves a `.mov` to a real matrix row + go op.
+ *   2. `submitConversion()` (the function `<DropZone />` calls when a file
+ *      arrives) POSTs the file to `/api/convert` exactly once.
+ *
+ * Together those guarantee that when `<HeroDrop />` matches the file and
+ * mounts a `<DropZone initialFile={file} />`, the conversion request fires
+ * without a second user action — which is the AC requirement.
+ *
+ * Test runner: `node --test` via ts-node (matches the rest of the suite).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { matrixRowForFile, routeForFile } from '../route-for-file';
+import { submitConversion } from '../submit-conversion';
+
+// ─────────────────────────────────────────────────────── HELPERS ─────────────
+
+/**
+ * Minimal File-shaped object that satisfies what `submitConversion` does with
+ * it (passes through to `FormData.append('file', …)`). Node's global `File`
+ * works fine in Node 20+; we wrap it so the test reads as "a fake File the
+ * user dropped".
+ */
+function fakeFile(name: string, body = 'binary-data-stub'): File {
+  return new File([body], name, { type: 'application/octet-stream' });
+}
+
+interface FetchCall {
+  url: string;
+  method: string;
+  body: FormData;
+}
+
+/**
+ * Build a fake fetch that records calls and returns a successful job
+ * response — same shape the real backend returns. Typed as `typeof fetch`
+ * via a cast because Node's lib.dom fetch signature mixes in extras
+ * (`preconnect`) that the test doesn't need to model.
+ */
+function recordingFetch(): {
+  fetch: typeof fetch;
+  calls: FetchCall[];
+} {
+  const calls: FetchCall[] = [];
+  const fetchImpl = async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    const method = init?.method ?? 'GET';
+    const body = init?.body as FormData;
+    calls.push({ url, method, body });
+    return new Response(
+      JSON.stringify({
+        job_id: 'test-job-id',
+        output: '/jobs/test-job-id/output',
+      }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    );
+  };
+  return { fetch: fetchImpl as typeof fetch, calls };
+}
+
+// ─────────────────────────────────────────────────────── TESTS ───────────────
+
+describe('SEAN-75 homepage drop — file is honoured without re-upload', () => {
+  it('matrixRowForFile resolves a dropped .mov to the mov-to-mp4 row', () => {
+    const match = matrixRowForFile(fakeFile('vacation.mov'));
+    assert.ok(match, 'expected a matrix row for .mov');
+    assert.equal(match.row.slug, 'mov-to-mp4');
+    assert.equal(match.row.outputFormat, 'mp4');
+    assert.equal(match.inputFormat, 'mov');
+    // The row must have a backend op so the homepage flow can actually run it.
+    assert.ok(match.row.goOp, 'matrix row must have a goOp');
+  });
+
+  it('matrixRowForFile and routeForFile agree on the target slug', () => {
+    // Belt-and-braces: the new helper must not diverge from the existing
+    // route-resolver. If they desynced, slug pages and the homepage flow
+    // could pick different targets for the same dropped file.
+    const exts = ['mov', 'mp4', 'webm', 'mkv', 'avi', 'png', 'heic', 'wav'];
+    for (const ext of exts) {
+      const file = fakeFile(`a.${ext}`);
+      const match = matrixRowForFile(file);
+      const path = routeForFile(file);
+      if (match) {
+        assert.ok(
+          path,
+          `routeForFile null but matrixRowForFile resolved .${ext}`,
+        );
+        assert.ok(
+          path.endsWith(`/${match.row.slug}`),
+          `path ${path} does not end with slug ${match.row.slug}`,
+        );
+      } else {
+        assert.equal(
+          path,
+          null,
+          `routeForFile resolved .${ext} but matrixRowForFile did not`,
+        );
+      }
+    }
+  });
+
+  it('submitConversion POSTs the dropped File to /api/convert exactly once', async () => {
+    // This is the upload that <DropZone initialFile={file} /> auto-fires on
+    // mount. Asserting it works end-to-end (file present in the multipart
+    // body, op + ext set, single request) covers the "no second user action"
+    // AC: when HeroDrop mounts the panel with the dropped File, this is the
+    // call that goes out.
+    const { fetch, calls } = recordingFetch();
+    const file = fakeFile('vacation.mov');
+    const match = matrixRowForFile(file);
+    assert.ok(match);
+
+    const job = await submitConversion({
+      file,
+      goOp: match.row.goOp,
+      outputExt: 'mp4',
+      fetchImpl: fetch,
+    });
+
+    assert.equal(calls.length, 1, 'expected exactly one /api/convert request');
+    const call = calls[0];
+    assert.ok(call, 'expected a recorded fetch call');
+    assert.equal(call.url, '/api/convert');
+    assert.equal(call.method, 'POST');
+    // The dropped File must be on the multipart body — that's the whole bug.
+    const sentFile = call.body.get('file');
+    assert.ok(sentFile, 'no file field on /api/convert request');
+    assert.ok(
+      typeof sentFile === 'object' && sentFile !== null && 'size' in sentFile,
+      'file field on /api/convert is not a File/Blob',
+    );
+    assert.equal(call.body.get('op'), match.row.goOp);
+    assert.equal(call.body.get('ext'), 'mp4');
+
+    // And the resolved job is shaped the way ResultBlock expects (so the
+    // reset path the AC mentions can render the download/try-another UI).
+    assert.equal(job.jobId, 'test-job-id');
+    assert.equal(job.downloadUrl, '/api/jobs/test-job-id/output');
+    assert.equal(job.inputFilename, 'vacation.mov');
+    assert.equal(job.outputExt, 'mp4');
+  });
+
+  it('submitConversion forwards extraArgs (preset hints) as form fields', async () => {
+    // Compress flagship rows carry preset.targetSizeMb — that has to land on
+    // the request body or the homepage in-place flow runs without the
+    // preset, producing a different output than the slug page would.
+    const { fetch, calls } = recordingFetch();
+    await submitConversion({
+      file: fakeFile('big.mp4'),
+      goOp: 'transcode',
+      outputExt: 'mp4',
+      extraArgs: { target_size_mb: '25', crf: '28' },
+      fetchImpl: fetch,
+    });
+    const call = calls[0];
+    assert.ok(call);
+    assert.equal(call.body.get('target_size_mb'), '25');
+    assert.equal(call.body.get('crf'), '28');
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
+++ b/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
@@ -1,0 +1,127 @@
+// SEAN-75 — shared row → ConverterPanel-args mapping.
+//
+// Both `<ToolPage />` (slug pages) and `<HeroDrop />` (homepage in-place
+// converter) need to translate an `OperationRow` into the props that
+// `<ConverterPanel />` expects: accept string, accept label, extraArgs, the
+// reverse-tool link, etc. Extracted here so the homepage flow can reuse the
+// exact same mapping the slug pages already use — no behavioural drift between
+// "drop on homepage" and "drop after landing on /convert/mov-to-mp4 from
+// Google".
+
+import { MATRIX_BY_SLUG } from '@/ops/matrix';
+import type { OperationRow } from '@/ops/types';
+import { pathForSlug, routeExistsForSlug } from './route-registry';
+
+/**
+ * Map a Format enum to the file extension used in URLs and filenames. Most
+ * formats are their own extension; the special-cases below cover the ones
+ * with longer names.
+ */
+export function formatToExt(format: string): string {
+  switch (format) {
+    case 'gif-static':
+      return 'gif';
+    case 'webp-anim':
+      return 'webp';
+    default:
+      return format;
+  }
+}
+
+/**
+ * Build the `<input accept>` attribute from the row's accepted input formats.
+ * Each format maps to its `.ext` form; we don't bother with MIME types since
+ * the backend validates anyway.
+ */
+export function buildAcceptString(row: OperationRow): string {
+  return row.inputFormats.map((f) => `.${formatToExt(f)}`).join(',');
+}
+
+/**
+ * Human-readable accept label for the drop zone copy. Single format → just
+ * the name (`MOV`); 2-3 formats → all listed; many formats → "video file" etc.
+ */
+export function buildAcceptLabel(row: OperationRow): string {
+  if (row.inputFormats.length === 0) return 'file';
+  if (row.inputFormats.length === 1) {
+    return formatToExt(row.inputFormats[0] ?? '').toUpperCase();
+  }
+  if (row.inputFormats.length <= 3) {
+    return row.inputFormats.map((f) => formatToExt(f).toUpperCase()).join(', ');
+  }
+  return 'video file';
+}
+
+/**
+ * Build the `extraArgs` map forwarded to the Go op. Pulls preset hints from
+ * the row (CRF, target size, FPS, etc.) — the backend reads them from the
+ * multipart form values.
+ */
+export function buildExtraArgs(
+  row: OperationRow,
+): Record<string, string> | undefined {
+  const args: Record<string, string> = {};
+  const p = row.preset;
+  if (!p) return undefined;
+  if (p.crf !== undefined) args.crf = String(p.crf);
+  if (p.preset !== undefined) args.preset = p.preset;
+  if (p.targetSizeMb !== undefined) {
+    args.target_size_mb = String(p.targetSizeMb);
+  }
+  if (p.resolution !== undefined) args.resolution = p.resolution;
+  if (p.fps !== undefined) args.fps = String(p.fps);
+  if (p.audioBitrate !== undefined) args.audio_bitrate = p.audioBitrate;
+  return Object.keys(args).length > 0 ? args : undefined;
+}
+
+export interface ReverseLink {
+  slug: string;
+  label: string;
+  operation: string;
+}
+
+/**
+ * Find the inverse-direction row (e.g. `mov-to-mp4` → `mp4-to-mov`). Only
+ * applies to two-format `convert` rows whose reverse slug is in the matrix
+ * AND whose route is implemented. Returns null otherwise — the converter
+ * panel hides the reverse-link CTA when this is null.
+ */
+export function findReverse(row: OperationRow): ReverseLink | null {
+  if (row.operation !== 'convert') return null;
+  if (row.inputFormats.length !== 1) return null;
+  const inputExt = formatToExt(row.inputFormats[0] ?? '');
+  const outputExt = formatToExt(row.outputFormat);
+  const reverseSlug = `${outputExt}-to-${inputExt}`;
+  const sib = MATRIX_BY_SLUG[reverseSlug];
+  if (!sib) return null;
+  if (!routeExistsForSlug(reverseSlug)) return null;
+  return {
+    slug: sib.slug,
+    label: sib.h1,
+    operation: sib.operation,
+  };
+}
+
+export interface SiblingLink {
+  slug: string;
+  label: string;
+  href: string;
+}
+
+/**
+ * Resolve `row.related` slugs against the matrix. Used by `<ToolPage />` for
+ * the "Related" sibling-link block. Lives here so it shares the same matrix
+ * + route-registry gating as the rest of the row → props mapping.
+ */
+export function resolveSiblings(row: OperationRow): SiblingLink[] {
+  const out: SiblingLink[] = [];
+  for (const slug of row.related ?? []) {
+    const sib = MATRIX_BY_SLUG[slug];
+    if (!sib) continue;
+    if (!routeExistsForSlug(slug)) continue;
+    const href = pathForSlug(slug);
+    if (!href) continue;
+    out.push({ slug, label: sib.h1, href });
+  }
+  return out;
+}

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -11,7 +11,7 @@
 // caller surfaces a "we don't recognise this format yet" message.
 
 import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
-import type { Format } from '@/ops/types';
+import type { Format, OperationRow } from '@/ops/types';
 import { pathForSlug, routeExistsForSlug } from './route-registry';
 
 /**
@@ -84,17 +84,46 @@ export function extOf(filename: string): string {
  * message rather than dumping the user on a 404.
  */
 export function routeForFile(file: File | { name: string }): string | null {
+  const match = matrixRowForFile(file);
+  if (!match) return null;
+  return pathForSlug(match.row.slug);
+}
+
+/**
+ * Resolved matrix row for a dropped file. Used by SEAN-75's homepage in-place
+ * conversion: instead of routing to a slug page (which loses the File object),
+ * the homepage drop zone runs the conversion right there with the row's
+ * backend op + output format already wired in.
+ */
+export interface MatrixRowMatch {
+  row: OperationRow;
+  /** Resolved input `Format` enum value (after `EXT_TO_FORMAT` normalisation). */
+  inputFormat: Format;
+}
+
+/**
+ * Look up the matrix row that corresponds to a given dropped file. Returns
+ * `null` under the same conditions as `routeForFile` (no extension, no
+ * preferred target, no matching row, or the row's operation route isn't
+ * implemented yet).
+ *
+ * Mirrors `routeForFile`'s preference order: direct `${input}-to-${target}`
+ * slug first, then a multi-input fallback row (e.g. `video-to-mp4`).
+ */
+export function matrixRowForFile(
+  file: File | { name: string },
+): MatrixRowMatch | null {
   const ext = extOf(file.name);
   if (!ext) return null;
 
-  const inputFormat = EXT_TO_FORMAT[ext] ?? ext;
+  const inputFormat = (EXT_TO_FORMAT[ext] ?? ext) as Format;
   const target = PREFERRED_TARGET_BY_EXT[ext];
   if (!target) return null;
 
-  // Try the direct `${input}-to-${target}` slug first.
   const directSlug = `${inputFormat}-to-${target}`;
-  if (routeExistsForSlug(directSlug)) {
-    return pathForSlug(directSlug);
+  const directRow = MATRIX_BY_SLUG[directSlug];
+  if (directRow && routeExistsForSlug(directSlug)) {
+    return { row: directRow, inputFormat };
   }
 
   // Fall back to multi-input rows like `video-to-mp4` (covers mkv/avi/flv/wmv
@@ -102,10 +131,10 @@ export function routeForFile(file: File | { name: string }): string | null {
   for (const row of MATRIX) {
     if (row.operation !== 'convert') continue;
     if (row.outputFormat !== target) continue;
-    if (!row.inputFormats.includes(inputFormat as Format)) continue;
+    if (!row.inputFormats.includes(inputFormat)) continue;
     if (!MATRIX_BY_SLUG[row.slug]) continue;
     if (!routeExistsForSlug(row.slug)) continue;
-    return pathForSlug(row.slug);
+    return { row, inputFormat };
   }
 
   return null;

--- a/apps/ffmpeg-converter/web/src/components/submit-conversion.ts
+++ b/apps/ffmpeg-converter/web/src/components/submit-conversion.ts
@@ -1,0 +1,60 @@
+// Pure HTTP layer: POST a single file to the backend `/api/convert` endpoint
+// and return a typed `ConversionJob`.
+//
+// Lives in its own (.ts, no JSX) module so the test runner can import it
+// without pulling in any React/tsx files. `<DropZone />` and the homepage
+// `<HeroDrop />` flow both call into this helper — the load-bearing path of
+// the SEAN-75 fix is "homepage drop forwards the File here exactly once,
+// without a second user action".
+
+export interface ConversionJob {
+  /** Backend job id, e.g. UUID. */
+  jobId: string;
+  /** Same-origin download URL (`/api/jobs/<id>/output`). */
+  downloadUrl: string;
+  /** Original input filename, used to name the downloaded result. */
+  inputFilename: string;
+  /** Output extension (without leading dot), e.g. `mp4`, `webp`, `mp3`. */
+  outputExt: string;
+}
+
+export interface SubmitConversionArgs {
+  file: File;
+  goOp: string;
+  outputExt: string;
+  extraArgs?: Record<string, string>;
+  /** Injectable for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export async function submitConversion(
+  args: SubmitConversionArgs,
+): Promise<ConversionJob> {
+  const { file, goOp, outputExt, extraArgs, fetchImpl } = args;
+  const f = fetchImpl ?? fetch;
+
+  const form = new FormData();
+  form.append('op', goOp);
+  form.append('file', file);
+  form.append('ext', outputExt);
+  if (extraArgs) {
+    for (const [k, v] of Object.entries(extraArgs)) {
+      if (v !== '') form.append(k, v);
+    }
+  }
+
+  const res = await f('/api/convert', { method: 'POST', body: form });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `${res.status} ${res.statusText}`);
+  }
+  const data = (await res.json()) as { job_id?: string; output?: string };
+  const jobId = data.job_id ?? '';
+  const downloadPath = data.output ?? `/jobs/${jobId}/output`;
+  return {
+    jobId,
+    downloadUrl: `/api${downloadPath}`,
+    inputFilename: file.name,
+    outputExt,
+  };
+}


### PR DESCRIPTION
Closes #75

## Summary
- Homepage drop no longer navigates — it runs the conversion in place via the same `<ConverterPanel />` the slug pages use, with the dropped File pre-loaded so the upload auto-fires on mount.
- Output format is chosen by `routeForFile()`'s preferred-target table (now exposed via the new `matrixRowForFile()` helper) — same routing decisions, no lost File.
- Extracted `<ToolPage />`'s row-to-props helpers into `converter-row-args.ts` so the homepage flow reuses the exact same mapping, and split `submitConversion()` into a JSX-free module so the upload path is unit-testable.

## Test plan
- [ ] `yarn test` (all 36 tests in apps/ffmpeg-converter/web) — including the new `HeroDrop.test.ts` which drives a fake `.mov` File through `matrixRowForFile` + `submitConversion` and asserts a single `/api/convert` POST fires with the file on the multipart body.
- [ ] Manual: visit `/`, drop a `.mov`, observe the conversion runs in place (no navigation, no second drop required).
- [ ] Manual: visit `/convert/mov-to-mp4` directly (simulating Google referral), observe the slug page still renders with its input-locked drop zone.
- [ ] Manual: after a successful conversion on the homepage, click "Try another file" — homepage hero drop zone returns.