### PR TITLE
[SEAN-80] feat: hub pages for thumbnail, contact-sheet, normalize-audio

### DIFF
--- a/apps/ffmpeg-converter/web/src/app/contact-sheet/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/contact-sheet/page.tsx
@@ -1,0 +1,34 @@
+// SEAN-80 — `/contact-sheet` hub page.
+//
+// Lists every `contact-sheet` row in the matrix. Catches queries like
+// "video contact sheet" or "grid of frames from mp4" that don't match a
+// specific slug, and ensures `seansconverter.com/contact-sheet` resolves
+// instead of 404ing.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Video contact sheet — NxM grid of frames, free',
+  description:
+    'Generate a contact sheet from any video — a grid of evenly-sampled frames in a single image. Useful for previewing long clips, picking a cover frame, or scrubbing for moments without scrubbing.',
+};
+
+const INTRO =
+  'A contact sheet is a single image that tiles a grid of frames sampled ' +
+  'evenly across a video. Drop a clip in, pick the grid size (3x3 by ' +
+  'default), and the converter samples frames at regular intervals, scales ' +
+  'each one down, and stitches them into one JPG. Useful for previewing a ' +
+  'long recording at a glance, picking a thumbnail without scrubbing, or ' +
+  'sharing a quick visual summary.';
+
+export default function ContactSheetHub() {
+  return (
+    <HubPage
+      operation="contact-sheet"
+      h1="Video contact sheet"
+      lede="A grid of evenly-sampled frames stitched into one image."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/normalize-audio/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/normalize-audio/page.tsx
@@ -1,0 +1,35 @@
+// SEAN-80 — `/normalize-audio` hub page.
+//
+// Lists the `normalize-audio` row in the matrix. Catches queries like
+// "normalise audio" or "loudness normalisation" that don't match a specific
+// slug, and ensures `seansconverter.com/normalize-audio` resolves instead
+// of 404ing.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Normalise audio loudness — EBU R128, free',
+  description:
+    'Level the perceived loudness of any audio file using EBU R128 loudness normalisation. Podcast (-16 LUFS), broadcast (-23 LUFS), or streaming (-14 LUFS) targets. Runs in your browser, no watermark.',
+};
+
+const INTRO =
+  'Loudness normalisation matches the perceived volume of a track to a ' +
+  'target loudness, not just its peak amplitude. Drop in any audio file and ' +
+  'the converter applies the EBU R128 loudnorm filter at a podcast, ' +
+  'broadcast, or streaming preset, so the output sits at the right level for ' +
+  'its destination without clipping. Better than peak normalisation when ' +
+  "you're stitching together episodes, lining up music tracks, or matching " +
+  'voiceover to background.';
+
+export default function NormalizeAudioHub() {
+  return (
+    <HubPage
+      operation="normalize-audio"
+      h1="Normalise audio"
+      lede="EBU R128 loudness normalisation — podcast, broadcast, or streaming targets."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/app/thumbnail/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/thumbnail/page.tsx
@@ -1,0 +1,33 @@
+// SEAN-80 — `/thumbnail` hub page.
+//
+// Lists every `thumbnail` row in the matrix. Catches queries like
+// "video thumbnail" or "grab a frame from mp4" that don't match a specific
+// slug, and ensures `seansconverter.com/thumbnail` resolves instead of 404ing.
+
+import type { Metadata } from 'next';
+import { HubPage } from '@/components/HubPage';
+
+export const metadata: Metadata = {
+  title: 'Grab a video thumbnail — JPG, PNG, WebP, free',
+  description:
+    'Pull a single frame out of any video file at the timestamp you choose. JPG by default, PNG and WebP available. Runs in your browser, no watermark, no signup.',
+};
+
+const INTRO =
+  'Grab a single frame from a video and save it as a still image. Pick the ' +
+  'timestamp, pick the output format (JPG for size, PNG for transparency, ' +
+  'WebP for both), and the converter pulls exactly one frame at that moment ' +
+  'without re-encoding the rest of the file. Useful for blog post hero ' +
+  'images, social-share previews, or scrubbing a long clip for the right ' +
+  'cover frame.';
+
+export default function ThumbnailHub() {
+  return (
+    <HubPage
+      operation="thumbnail"
+      h1="Video thumbnail"
+      lede="Pull a single frame out of any video at the timestamp you pick."
+      intro={INTRO}
+    />
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
@@ -29,6 +29,8 @@ import {
 // SEAN-56 — hub-page routes added in this ticket. Listed here so the
 // dead-link walk recognises them as real, and so the footer's "Browse:"
 // nav row (which links into them) doesn't trip the homepage assertion.
+// SEAN-80 added the remaining three (thumbnail, contact-sheet, normalize-audio)
+// so every operation segment resolves as a hub page rather than 404ing.
 const HUB_ROUTES = [
   '/convert',
   '/compress',
@@ -36,6 +38,9 @@ const HUB_ROUTES = [
   '/trim',
   '/resize',
   '/gif',
+  '/thumbnail',
+  '/contact-sheet',
+  '/normalize-audio',
 ];
 
 // ─────────────────────────────────────────────────────── HELPERS ─────────────


### PR DESCRIPTION
Closes #80

## Summary

- Adds `/thumbnail`, `/contact-sheet`, `/normalize-audio` hub pages so every operation segment with an implemented `[slug]` route resolves to a HubPage rather than the Next.js 404 default.
- Reuses the SEAN-56 shared `HubPage` component — pure server-rendered card grid, filtered to one operation, sorted by intent volume.
- Footer Browse row left at 6 hubs per AC: each new op currently has a single matrix row, so a footer link there would point at a near-empty card grid. The pages still catch fuzzy bare-URL traffic, sitemap inclusion, and external links.
- Dead-links test extended so its `HUB_ROUTES` knows the three new paths exist.

## Test plan

- [x] `cd apps/ffmpeg-converter/web && yarn test` — all 5 suites pass (dead-links, matrix, sitemap, redirects, word-count)
- [x] `cd apps/ffmpeg-converter/web && npx tsc --noEmit` — clean
- [ ] Visit `/thumbnail`, `/contact-sheet`, `/normalize-audio` and confirm each renders a hub with at least one card linking to its slug page
- [ ] Visit any tool slug under those ops (e.g. `/thumbnail/thumbnail-mp4`) and confirm it still resolves