### PR TITLE
[SEAN-78] feat: friendly fallback when homepage drop hits unmapped extension

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -13,7 +13,8 @@
     "test:sitemap": "ts-node -P tsconfig.test.json src/ops/sitemap.test.ts",
     "test:redirects": "ts-node -P tsconfig.test.json src/ops/redirects.test.ts",
     "test:word-count": "ts-node -P tsconfig.test.json src/ops/word-count.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count"
+    "test:route-for-file": "ts-node -P tsconfig.test.json src/components/__tests__/route-for-file.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:route-for-file"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -10,7 +10,7 @@
 
 import { useRouter } from 'next/navigation';
 import { type DragEvent, useRef, useState } from 'react';
-import { extOf, routeForFile } from './route-for-file';
+import { friendlyDropError, routeForFile } from './route-for-file';
 
 export function HeroDrop() {
   const router = useRouter();
@@ -22,14 +22,12 @@ export function HeroDrop() {
     // SEAN-50: routeForFile only returns paths that resolve to a real route
     // (matrix slug + implemented operation). Anything else falls through to
     // the friendly error rather than routing the user to a 404.
+    // SEAN-78: the error now lists the matrix-supported families ("video,
+    // audio, images") rather than naming only video extensions, so users
+    // dropping a .png/.mp3/.flac get a recommendation instead of a flat "no".
     const target = routeForFile(file);
     if (!target) {
-      const ext = extOf(file.name);
-      setError(
-        ext
-          ? `We don't recognise .${ext} yet. Try MOV, MP4, WebM, MKV, AVI, FLV, WMV, M4V, or MPEG.`
-          : "That file doesn't have an extension we can route on.",
-      );
+      setError(friendlyDropError(file.name));
       return;
     }
     setError(null);

--- a/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/dead-links.test.ts
@@ -109,7 +109,10 @@ function homepageLinks(): string[] {
   // PREFERRED_TARGET_BY_EXT table. We can't import that table directly (it's
   // module-private), so we exercise routeForFile() with a representative file
   // per extension.
+  // SEAN-78: extended to cover the audio/image families and the rare video
+  // formats (3gp/ts/mts/m2ts/ogv/vob/avif/webp) the matrix supports.
   const candidateExts = [
+    // video
     'mov',
     'webm',
     'mkv',
@@ -120,6 +123,13 @@ function homepageLinks(): string[] {
     'mpeg',
     'mpg',
     'mp4',
+    '3gp',
+    'ts',
+    'mts',
+    'm2ts',
+    'ogv',
+    'vob',
+    // image
     'jpg',
     'jpeg',
     'png',
@@ -128,12 +138,16 @@ function homepageLinks(): string[] {
     'bmp',
     'tiff',
     'tif',
+    'avif',
+    'webp',
+    // audio
     'wav',
     'flac',
     'aac',
     'ogg',
     'm4a',
     'opus',
+    'mp3',
   ];
   for (const ext of candidateExts) {
     const target = routeForFile({ name: `dummy.${ext}` });
@@ -214,7 +228,9 @@ describe('SEAN-50 dead-links — every internal link resolves', () => {
   it('routeForFile only returns paths that resolve', () => {
     // Walk every plausible extension. routeForFile returns null for unknown
     // ones — that's fine. Anything it returns must be a real route.
+    // SEAN-78: extended to cover audio/image and rare video formats.
     const exts = [
+      // video
       'mov',
       'webm',
       'mkv',
@@ -225,6 +241,13 @@ describe('SEAN-50 dead-links — every internal link resolves', () => {
       'mpeg',
       'mpg',
       'mp4',
+      '3gp',
+      'ts',
+      'mts',
+      'm2ts',
+      'ogv',
+      'vob',
+      // image
       'jpg',
       'jpeg',
       'png',
@@ -233,12 +256,17 @@ describe('SEAN-50 dead-links — every internal link resolves', () => {
       'bmp',
       'tiff',
       'tif',
+      'avif',
+      'webp',
+      // audio
       'wav',
       'flac',
       'aac',
       'ogg',
       'm4a',
       'opus',
+      'mp3',
+      // genuinely unknown
       'unknown-ext',
     ];
     for (const ext of exts) {

--- a/apps/ffmpeg-converter/web/src/components/__tests__/route-for-file.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/route-for-file.test.ts
@@ -1,0 +1,166 @@
+/**
+ * SEAN-78 — homepage drop-zone routing invariants.
+ *
+ * Two invariants this test guards:
+ *   1. `PREFERRED_TARGET_BY_EXT` is reconciled with the matrix — every
+ *      input format the matrix can handle on a routable row resolves to a
+ *      real path via `routeForFile`. Nothing should silently fall through
+ *      to the friendly-error path just because the routing table forgot to
+ *      list a new format.
+ *   2. The friendly error names the matrix-supported families and gives
+ *      sensible example extensions, not a hand-rolled "video formats only"
+ *      list that drifts out of sync with reality.
+ *
+ * Test runner: `node --test` via ts-node (matches the rest of the suite).
+ * Run via: `yarn test:route-for-file` (wired in package.json).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  extOf,
+  friendlyDropError,
+  matrixInputExtensions,
+  routeForFile,
+} from '../route-for-file';
+import { routeExistsForSlug } from '../route-registry';
+
+describe('SEAN-78 route-for-file — every matrix input has a routing target', () => {
+  it('every matrix input extension routes to a real path', () => {
+    const exts = matrixInputExtensions();
+    assert.ok(
+      exts.length > 0,
+      'matrix should expose at least one routable input format',
+    );
+    const failures: string[] = [];
+    for (const ext of exts) {
+      const target = routeForFile({ name: `dummy.${ext}` });
+      if (target === null) {
+        failures.push(
+          `routeForFile('.${ext}') returned null — add to PREFERRED_TARGET_BY_EXT`,
+        );
+        continue;
+      }
+      // The path must resolve to a real route too.
+      // pathForSlug strips the leading slash and the operation prefix when
+      // building paths; we re-derive the slug from the path's last segment
+      // and ask the registry directly.
+      const slug = target.split('/').filter(Boolean).pop();
+      if (!slug) {
+        failures.push(
+          `routeForFile('.${ext}') returned ${target} — couldn't extract a slug`,
+        );
+        continue;
+      }
+      if (!routeExistsForSlug(slug)) {
+        failures.push(
+          `routeForFile('.${ext}') returned ${target}, slug ${slug} doesn't resolve`,
+        );
+      }
+    }
+    assert.equal(
+      failures.length,
+      0,
+      `unmapped matrix inputs:\n  ${failures.join('\n  ')}`,
+    );
+  });
+
+  it('every common user extension alias routes to a real path', () => {
+    // Aliases the matrix doesn't list verbatim but real users drop:
+    // jpeg → jpg, heif → heic, mpg → mpeg. These should route. (TIFF/BMP
+    // aren't matrix inputs today — those land on the friendly-error path.)
+    const aliases = ['jpeg', 'heif', 'mpg'];
+    for (const ext of aliases) {
+      const target = routeForFile({ name: `photo.${ext}` });
+      assert.ok(
+        target !== null,
+        `routeForFile('.${ext}') returned null — common alias should route`,
+      );
+    }
+  });
+
+  it('returns null for genuinely unknown extensions', () => {
+    assert.equal(routeForFile({ name: 'mystery.xyz' }), null);
+    assert.equal(routeForFile({ name: 'no-extension' }), null);
+    assert.equal(routeForFile({ name: 'empty.' }), null);
+  });
+
+  it('friendlyDropError names the matrix-supported families', () => {
+    const msg = friendlyDropError('mystery.xyz');
+    // Should mention the file extension we couldn't handle.
+    assert.ok(
+      msg.includes('.xyz'),
+      `error should mention .xyz: ${JSON.stringify(msg)}`,
+    );
+    // Should mention each supported family that the matrix actually covers.
+    // We don't hard-code which families because they're derived from the
+    // matrix; instead we assert at least video and image families show up
+    // since the matrix definitely has both.
+    assert.ok(
+      msg.includes('video'),
+      `error should mention video: ${JSON.stringify(msg)}`,
+    );
+    assert.ok(
+      msg.includes('image'),
+      `error should mention images: ${JSON.stringify(msg)}`,
+    );
+    // Examples should include at least one common extension per family.
+    assert.ok(
+      msg.includes('.mp4') || msg.includes('.mov'),
+      `error should suggest a video example: ${JSON.stringify(msg)}`,
+    );
+  });
+
+  it('friendlyDropError handles missing extension', () => {
+    const msg = friendlyDropError('no-extension');
+    assert.ok(
+      msg.toLowerCase().includes('extension'),
+      `error should mention missing extension: ${JSON.stringify(msg)}`,
+    );
+  });
+
+  it('extOf normalises common extension shapes', () => {
+    assert.equal(extOf('foo.MP4'), 'mp4');
+    assert.equal(extOf('bare'), '');
+    assert.equal(extOf('a.b.tiff'), 'tiff');
+    assert.equal(extOf('trailing-dot.'), '');
+  });
+
+  it('audio inputs route to a real audio page', () => {
+    // SEAN-78: the matrix has no audio-to-audio convert rows yet, but
+    // dropping an audio file should still land somewhere useful instead
+    // of the friendly-error path. /normalize-audio/ is the bridge today.
+    for (const ext of ['mp3', 'wav', 'flac', 'aac', 'ogg', 'm4a', 'opus']) {
+      const target = routeForFile({ name: `track.${ext}` });
+      assert.ok(
+        target !== null,
+        `audio input .${ext} should route somewhere — got null`,
+      );
+    }
+  });
+
+  it('image inputs (incl. avif/webp) route to a real image page', () => {
+    // SEAN-78: avif and webp were listed by the matrix but missing from
+    // PREFERRED_TARGET_BY_EXT, so they fell through to the friendly error.
+    for (const ext of ['jpg', 'png', 'heic', 'avif', 'webp']) {
+      const target = routeForFile({ name: `pic.${ext}` });
+      assert.ok(
+        target !== null,
+        `image input .${ext} should route somewhere — got null`,
+      );
+    }
+  });
+
+  it('rare video formats (3gp, ts, mts, m2ts, ogv, vob) all route', () => {
+    // SEAN-78: these are matrix-supported but were missing from the
+    // routing table.
+    for (const ext of ['3gp', 'ts', 'mts', 'm2ts', 'ogv', 'vob']) {
+      const target = routeForFile({ name: `clip.${ext}` });
+      assert.ok(
+        target !== null,
+        `video input .${ext} should route somewhere — got null`,
+      );
+    }
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -9,9 +9,16 @@
 // than maintaining a hand-rolled extension map that drifts out of sync with
 // the matrix. Anything not covered by the matrix returns `null`, and the
 // caller surfaces a "we don't recognise this format yet" message.
+//
+// SEAN-78: reconciled the routing table with every matrix input format so
+// dropping an image (avif/webp) or audio file no longer falls through to
+// the friendly-error path. The audio family is routed to `/normalize-audio/`
+// because the matrix today has no audio-to-audio convert rows — that gap is
+// documented in `AUDIO_FALLBACK_NOTE` below.
 
 import { MATRIX, MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { Format } from '@/ops/types';
+import { KIND_OF } from '@/ops/types';
 import { pathForSlug, routeExistsForSlug } from './route-registry';
 
 /**
@@ -19,6 +26,10 @@ import { pathForSlug, routeExistsForSlug } from './route-registry';
  * a `${ext}-to-${target}` slug actually exists — these are just preference
  * hints (e.g. iPhone HEIC photos default to JPG, not WebP, because that's
  * what most users actually want).
+ *
+ * SEAN-78: every input format the matrix can handle has an entry here. The
+ * `route-for-file.test.ts` test asserts this invariant so future matrix
+ * additions can't quietly drop off the homepage drop zone.
  */
 const PREFERRED_TARGET_BY_EXT: Record<string, Format> = {
   // Video: MP4 is the universal default.
@@ -31,37 +42,77 @@ const PREFERRED_TARGET_BY_EXT: Record<string, Format> = {
   m4v: 'mp4',
   mpeg: 'mp4',
   mpg: 'mp4',
+  '3gp': 'mp4',
+  ts: 'mp4',
+  mts: 'mp4',
+  m2ts: 'mp4',
+  ogv: 'mp4',
+  vob: 'mp4',
   // MP4 → WebM (browser-native, smaller).
   mp4: 'webm',
 
-  // Image: WebP for the modern web; HEIC defaults to JPG (compatibility).
+  // Image: WebP for the modern web; HEIC/AVIF/legacy formats default to JPG
+  // for compatibility (Discord previews, Outlook attachments, older CMSes).
+  // Note: bmp/tiff/tif aren't matrix inputs today — dropping one returns null,
+  // which fires the friendly-error path. Add them here if/when the matrix
+  // grows a row that accepts them.
   jpg: 'webp',
   jpeg: 'webp',
   png: 'webp',
   heic: 'jpg',
   heif: 'jpg',
-  bmp: 'jpg',
-  tiff: 'jpg',
-  tif: 'jpg',
+  avif: 'jpg',
+  webp: 'jpg',
 
-  // Audio: MP3 is universal.
-  wav: 'mp3',
-  flac: 'mp3',
-  aac: 'mp3',
-  ogg: 'mp3',
-  m4a: 'mp3',
-  opus: 'mp3',
+  // Audio: the matrix has no audio-to-audio `convert` rows today — every
+  // audio input lands on `/normalize-audio/normalize-audio` which is the only
+  // audio→audio op currently implemented. Once audio-convert rows ship, swap
+  // these targets to the appropriate format. See `AUDIO_FALLBACK_NOTE`.
+  mp3: 'wav',
+  wav: 'wav',
+  flac: 'wav',
+  aac: 'wav',
+  ogg: 'wav',
+  m4a: 'wav',
+  opus: 'wav',
 };
 
 // Some input extensions normalise to a different `Format` enum value (the
 // matrix uses canonical names). Phase 1 only needs `jpeg → jpg`, `mpg → mpeg`,
-// `tif → tiff`, `heif → heic`. Anything else is a one-to-one mapping.
+// `heif → heic`. Anything else is a one-to-one mapping.
+//
+// `tif → tiff` was here historically but neither `tif` nor `tiff` is a matrix
+// `Format`, so `routeForFile('.tif')` always returned null. Dropped from this
+// map until the matrix grows TIFF support.
 const EXT_TO_FORMAT: Record<string, string> = {
   jpeg: 'jpg',
   mpg: 'mpeg',
-  tif: 'tiff',
   heif: 'heic',
 };
+
+/**
+ * Operations whose matrix rows are eligible as "did the user drop a file we
+ * can convert?" targets. `convert` covers the bulk of video/audio conversion;
+ * `image-convert` covers JPG/PNG/HEIC/etc.; `normalize-audio` is the bridge
+ * we use today for audio inputs since the matrix has no audio-to-audio
+ * convert rows.
+ */
+const ROUTABLE_OPERATIONS: ReadonlySet<string> = new Set([
+  'convert',
+  'image-convert',
+  'normalize-audio',
+]);
+
+/**
+ * Documents the matrix gap: there are no audio→audio `convert` rows. Routing
+ * audio drops to `normalize-audio` is the least-bad fallback — it's a real
+ * audio-out page that accepts every common audio input, even if the user
+ * actually wanted a transcode rather than a loudness adjustment. When audio
+ * convert rows ship, drop this fallback and update PREFERRED_TARGET_BY_EXT
+ * to point at the new convert slugs.
+ */
+export const AUDIO_FALLBACK_NOTE =
+  'No audio-to-audio convert rows in the matrix yet — audio drops fall back to /normalize-audio/.';
 
 /**
  * Lowercase extension without the leading dot, or `''` if the filename has no
@@ -77,11 +128,11 @@ export function extOf(filename: string): string {
  * Pick the tool-page path to route to for a given file. Returns `null` when
  *   - the file has no extension
  *   - the extension isn't in our preference table
- *   - the matrix has no `${ext}-to-${target}` row
+ *   - the matrix has no row that accepts the (input, target) pair
  *   - the matrix row exists but its operation route isn't implemented yet
  *
  * The caller should surface a friendly "we don't recognise this format yet"
- * message rather than dumping the user on a 404.
+ * message rather than dumping the user on a 404 — see `friendlyDropError`.
  */
 export function routeForFile(file: File | { name: string }): string | null {
   const ext = extOf(file.name);
@@ -91,16 +142,19 @@ export function routeForFile(file: File | { name: string }): string | null {
   const target = PREFERRED_TARGET_BY_EXT[ext];
   if (!target) return null;
 
-  // Try the direct `${input}-to-${target}` slug first.
+  // Try the direct `${input}-to-${target}` slug first — covers the bulk of
+  // single-input convert/extract-audio rows.
   const directSlug = `${inputFormat}-to-${target}`;
   if (routeExistsForSlug(directSlug)) {
     return pathForSlug(directSlug);
   }
 
-  // Fall back to multi-input rows like `video-to-mp4` (covers mkv/avi/flv/wmv
-  // /m4v/mpeg → mp4 from a single matrix row).
+  // Fall back to multi-input rows. `convert` rows like `video-to-mp4` cover
+  // mkv/avi/flv/wmv/m4v/mpeg → mp4 from a single row. `image-convert` rows
+  // like `image-to-jpg` cover jpg/png/heic/webp/avif → jpg. `normalize-audio`
+  // accepts every audio format and outputs wav.
   for (const row of MATRIX) {
-    if (row.operation !== 'convert') continue;
+    if (!ROUTABLE_OPERATIONS.has(row.operation)) continue;
     if (row.outputFormat !== target) continue;
     if (!row.inputFormats.includes(inputFormat as Format)) continue;
     if (!MATRIX_BY_SLUG[row.slug]) continue;
@@ -109,4 +163,109 @@ export function routeForFile(file: File | { name: string }): string | null {
   }
 
   return null;
+}
+
+/**
+ * Build a friendly error message for a dropped file we can't route. Lists the
+ * matrix-supported input families ("video, audio, images") plus a few
+ * representative extensions so the user knows what _will_ work — instead of
+ * the old "Try MOV, MP4, WebM, ..." message that named only video formats.
+ *
+ * Caller is `HeroDrop.handleFile`; pure function so it's easy to unit-test.
+ */
+export function friendlyDropError(filename: string): string {
+  const ext = extOf(filename);
+  if (!ext) {
+    return "That file doesn't have an extension we can route on.";
+  }
+  const families = matrixSupportedFamilies();
+  return `We can't convert .${ext} yet. We handle ${joinList(families.kinds)} — try ${joinList(families.examples, 'or')}.`;
+}
+
+/**
+ * Collect the media kinds the matrix actually supports (by scanning every
+ * input format on every routable row) plus a representative extension per
+ * kind for the user-facing examples list. Computed at module load — the
+ * matrix is static, so this is a one-shot pass.
+ */
+function matrixSupportedFamilies(): {
+  kinds: string[];
+  examples: string[];
+} {
+  const kindSet = new Set<string>();
+  const exampleByKind = new Map<string, string>();
+  // Order matters for a friendly message: video, audio, images.
+  const KIND_ORDER: string[] = ['video', 'audio', 'image', 'animated-image'];
+  const KIND_LABEL: Record<string, string> = {
+    video: 'video',
+    audio: 'audio',
+    image: 'images',
+    'animated-image': 'animated images',
+  };
+  // Pick a memorable extension per kind for the examples list.
+  const PREFERRED_EXAMPLE: Record<string, string[]> = {
+    video: ['mp4', 'mov'],
+    audio: ['mp3', 'wav'],
+    image: ['png', 'jpg', 'heic'],
+    'animated-image': ['gif'],
+  };
+
+  for (const row of MATRIX) {
+    if (!ROUTABLE_OPERATIONS.has(row.operation)) continue;
+    if (!routeExistsForSlug(row.slug)) continue;
+    for (const f of row.inputFormats) {
+      const kind = KIND_OF[f];
+      if (kind) kindSet.add(kind);
+    }
+  }
+
+  const kinds: string[] = [];
+  const examples: string[] = [];
+  for (const k of KIND_ORDER) {
+    if (!kindSet.has(k)) continue;
+    kinds.push(KIND_LABEL[k] ?? k);
+    for (const ext of PREFERRED_EXAMPLE[k] ?? []) {
+      examples.push(`.${ext}`);
+      if (!exampleByKind.has(k)) exampleByKind.set(k, ext);
+      break;
+    }
+  }
+  // Add a couple of extra examples so the list reads like a recommendation,
+  // not a one-of-each enumeration.
+  if (kindSet.has('video') && !examples.includes('.mov')) examples.push('.mov');
+  if (kindSet.has('image') && !examples.includes('.png')) examples.push('.png');
+
+  return { kinds, examples };
+}
+
+/**
+ * Join a list as "a, b, and c" / "a, b, or c". Empty list → empty string.
+ */
+function joinList(items: string[], conjunction: 'and' | 'or' = 'and'): string {
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  if (items.length === 2) return `${items[0]} ${conjunction} ${items[1]}`;
+  return `${items.slice(0, -1).join(', ')}, ${conjunction} ${items[items.length - 1]}`;
+}
+
+/**
+ * Every input extension the matrix accepts as a routable input. Exposed for
+ * the `route-for-file.test.ts` invariant: every matrix input must have a
+ * `PREFERRED_TARGET_BY_EXT` entry, and that target must resolve to a real
+ * route. Used by tests only; not imported from runtime code.
+ */
+export function matrixInputExtensions(): string[] {
+  const exts = new Set<string>();
+  for (const row of MATRIX) {
+    if (!ROUTABLE_OPERATIONS.has(row.operation)) continue;
+    if (!routeExistsForSlug(row.slug)) continue;
+    for (const f of row.inputFormats) {
+      // Map matrix `Format` back to the user-visible extension. The
+      // `EXT_TO_FORMAT` map normalises `jpeg → jpg` etc., but the *matrix*
+      // canonical names are also valid extensions (a user dropping a `.jpg`
+      // file uses `jpg` directly). So we add the canonical name verbatim.
+      exts.add(f);
+    }
+  }
+  return [...exts].sort();
 }


### PR DESCRIPTION
Closes #78

## Summary

- Reconciled `PREFERRED_TARGET_BY_EXT` with the matrix: every routable input format now has a target. Added `3gp`/`ts`/`mts`/`m2ts`/`ogv`/`vob` (video), `avif`/`webp` (image), and the full audio family (`mp3`/`wav`/`flac`/`aac`/`ogg`/`m4a`/`opus`).
- Audio drops fall back to `/normalize-audio/normalize-audio` since the matrix has no audio-to-audio convert rows yet — gap documented in `AUDIO_FALLBACK_NOTE`.
- The friendly error now lists the matrix-supported families and example extensions ("We can't convert .xyz yet. We handle video, audio, and images — try .mp4, .mp3, .png, or .mov.") instead of naming only video formats.
- New `route-for-file.test.ts` enforces the invariant: every matrix input extension routes to a real path.

## Test plan

- [x] `yarn test` in `apps/ffmpeg-converter/web` — all 6 suites pass (41 tests)
- [x] `yarn tsc --noEmit` clean
- [x] Drop a `.png` / `.jpg` / `.heic` on the homepage drop zone → routes to `/convert/image-to-webp` or `/convert/image-to-jpg`
- [x] Drop a `.mp3` / `.wav` / `.flac` → routes to `/normalize-audio/normalize-audio`
- [x] Drop a `.3gp` / `.vob` / `.mts` → routes to `/convert/video-to-mp4`
- [x] Drop a `.zip` / `.xyz` → friendly error names video/audio/images families with example extensions