### PR TITLE
[SEAN-79] feat: output format picker on homepage

### DIFF
--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -6,18 +6,31 @@
 // page — but the `File` object lived in this component's memory and never
 // made it to the destination, so the user had to drop it a second time. The
 // cancellation rate at that step was the central UX failure of the funnel.
+// We fixed that by running the conversion in place via the same
+// `<ConverterPanel />` the slug pages use, with the File pre-loaded.
 //
-// New behaviour (Option A — KISS): the homepage runs the conversion in
-// place. We pick the matrix row using the same preference table as the old
-// `routeForFile`, mount the same `<ConverterPanel />` the slug pages use, and
-// hand it the dropped File via `initialFile` so it auto-fires the upload on
-// mount. No navigation, no lost File, one drop.
+// SEAN-79: the homepage now also lets the user re-pick the output format
+// before the conversion fires. Drop a `.mov` and the picker shows MP4
+// (default), WEBM, MOV — chip row, FlagshipPills-style, no modal. The slug
+// pages still lock the format on the slug (someone landing on
+// `/convert/mov-to-mp4` from Google wants exactly mp4), but the homepage
+// drop zone is the converter and a fixed target there is artificially
+// limiting.
+//
+// Flow on the homepage:
+//   1. User drops a file. We resolve the matrix row for the preferred target.
+//   2. We show: file name + chip row of available outputs + Convert button.
+//      The default chip is highlighted; the user can click another chip to
+//      change the target (single click — no third step). We do NOT auto-fire
+//      the upload here, because the user might want to re-pick.
+//   3. User clicks Convert. We mount `<ConverterPanel initialFile={file} />`
+//      with the picked row, and the panel auto-fires the upload on mount.
 //
 // SEO is unaffected: someone landing on `/convert/mov-to-mp4` directly from
 // Google still gets the slug page with its input-locked drop zone — those
-// pages are unchanged.
+// pages don't render the picker (slug owns intent).
 
-import { type DragEvent, useRef, useState } from 'react';
+import { type DragEvent, useMemo, useRef, useState } from 'react';
 import { ConverterPanel } from './ConverterPanel';
 import {
   buildAcceptLabel,
@@ -27,21 +40,31 @@ import {
   formatToExt,
 } from './converter-row-args';
 import {
+  extOf,
   friendlyDropError,
   type MatrixRowMatch,
   matrixRowForFile,
+  type OutputOption,
+  outputsForExt,
 } from './route-for-file';
 
-interface ActiveJob {
-  file: File;
-  match: MatrixRowMatch;
-}
+/**
+ * SEAN-79 internal state machine:
+ *   - null      → empty hero drop zone (initial)
+ *   - 'picking' → file dropped, picker visible, awaiting Convert click
+ *   - 'running' → user clicked Convert (or only one option), ConverterPanel
+ *                 is mounted with `initialFile` so the upload auto-fires
+ */
+type Stage =
+  | { kind: 'idle' }
+  | { kind: 'picking'; file: File; match: MatrixRowMatch }
+  | { kind: 'running'; file: File; match: MatrixRowMatch };
 
 export function HeroDrop() {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [active, setActive] = useState<ActiveJob | null>(null);
+  const [stage, setStage] = useState<Stage>({ kind: 'idle' });
 
   const handleFile = (file: File) => {
     // SEAN-50 / SEAN-75: matrixRowForFile only resolves to rows whose
@@ -57,7 +80,7 @@ export function HeroDrop() {
       return;
     }
     setError(null);
-    setActive({ file, match });
+    setStage({ kind: 'picking', file, match });
   };
 
   const handleDrop = (e: DragEvent<HTMLDivElement>) => {
@@ -76,10 +99,21 @@ export function HeroDrop() {
 
   const handleClick = () => inputRef.current?.click();
 
-  // Conversion in flight (or done) — render the same ConverterPanel the slug
-  // pages use, with the file pre-loaded so the upload auto-fires on mount.
-  if (active) {
-    const { row } = active.match;
+  if (stage.kind === 'picking') {
+    return (
+      <FormatPicker
+        file={stage.file}
+        defaultMatch={stage.match}
+        onConvert={(match) =>
+          setStage({ kind: 'running', file: stage.file, match })
+        }
+        onCancel={() => setStage({ kind: 'idle' })}
+      />
+    );
+  }
+
+  if (stage.kind === 'running') {
+    const { row } = stage.match;
     const reverse = findReverse(row);
     return (
       <ConverterPanel
@@ -92,12 +126,12 @@ export function HeroDrop() {
         reverseSlug={reverse?.slug}
         reverseLabel={reverse?.label}
         reverseOperation={reverse?.operation}
-        initialFile={active.file}
+        initialFile={stage.file}
         // SEAN-75: "Try another file" on the homepage tears the converter
         // back down to the original hero drop zone, so the user lands on a
         // clean, recognisable homepage state instead of an empty slug-shaped
         // panel.
-        onReset={() => setActive(null)}
+        onReset={() => setStage({ kind: 'idle' })}
       />
     );
   }
@@ -157,6 +191,135 @@ export function HeroDrop() {
           {error}
         </p>
       )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────── FORMAT PICKER ───────────
+
+interface FormatPickerProps {
+  file: File;
+  /**
+   * Default-target match resolved by `matrixRowForFile` from the dropped file.
+   * Used as the initial selection and to seed the input ext for `outputsForExt`.
+   */
+  defaultMatch: MatrixRowMatch;
+  /** Fired when the user clicks Convert. Carries the resolved row. */
+  onConvert: (match: MatrixRowMatch) => void;
+  /** Fired when the user backs out (e.g. wrong file). */
+  onCancel: () => void;
+}
+
+/**
+ * SEAN-79 — homepage-only format picker. Server-renderable (the option list
+ * is pure-function of input ext + matrix). Hidden from slug pages — those
+ * lock the format on the slug.
+ */
+function FormatPicker({
+  file,
+  defaultMatch,
+  onConvert,
+  onCancel,
+}: FormatPickerProps) {
+  const ext = extOf(file.name);
+  const options = useMemo(() => outputsForExt(ext), [ext]);
+
+  // The picker only renders when there's at least one option. If `outputsForExt`
+  // returns nothing (shouldn't happen — `matrixRowForFile` already resolved a
+  // row, so at least the default row is in the matrix) we still surface the
+  // default so the user has a way to convert.
+  const initialFormat = defaultMatch.row.outputFormat;
+  const [selectedFormat, setSelectedFormat] = useState(initialFormat);
+
+  const selectedOption =
+    options.find((o) => o.format === selectedFormat) ??
+    ({
+      row: defaultMatch.row,
+      format: defaultMatch.row.outputFormat,
+      label: formatToExt(defaultMatch.row.outputFormat).toUpperCase(),
+      isDefault: true,
+    } satisfies OutputOption);
+
+  const handleConvert = () => {
+    onConvert({
+      row: selectedOption.row,
+      inputFormat: defaultMatch.inputFormat,
+    });
+  };
+
+  return (
+    <div
+      className={[
+        'flex w-full flex-col items-center justify-center',
+        'rounded-2xl border-2 border-dashed border-gray-700 bg-gray-900/40',
+        'px-6 py-10 text-center',
+      ].join(' ')}
+    >
+      <div aria-hidden className="mb-3 text-4xl">
+        {'\u{1F4C4}'}
+      </div>
+      <div className="max-w-full truncate text-base font-medium text-gray-100">
+        {file.name}
+      </div>
+
+      <div className="mt-6 w-full">
+        <div className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400">
+          Convert to
+        </div>
+        <ul
+          aria-label="Output format"
+          className="flex flex-wrap justify-center gap-2"
+        >
+          {options.map((option) => {
+            const selected = option.format === selectedFormat;
+            return (
+              <li key={option.format}>
+                <button
+                  type="button"
+                  aria-pressed={selected}
+                  onClick={() => setSelectedFormat(option.format)}
+                  className={[
+                    'inline-flex items-center rounded-full',
+                    'border px-4 py-2 text-sm font-medium transition-colors',
+                    selected
+                      ? 'border-indigo-400 bg-indigo-500/20 text-white'
+                      : 'border-gray-700 bg-gray-900/60 text-gray-100 hover:border-indigo-500 hover:bg-indigo-500/10',
+                  ].join(' ')}
+                >
+                  {option.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <button
+          type="button"
+          onClick={handleConvert}
+          className={[
+            'inline-flex items-center rounded-full',
+            'border border-indigo-400 bg-indigo-500 px-6 py-2',
+            'font-semibold text-sm text-white',
+            'transition-colors hover:bg-indigo-400',
+          ].join(' ')}
+        >
+          Convert to {selectedOption.label}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className={[
+            'inline-flex items-center rounded-full',
+            'border border-gray-700 bg-transparent px-4 py-2',
+            'text-gray-400 text-sm',
+            'transition-colors hover:border-gray-600 hover:text-gray-300',
+          ].join(' ')}
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/ffmpeg-converter/web/src/components/__tests__/HeroDrop.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/HeroDrop.test.ts
@@ -22,7 +22,11 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
-import { matrixRowForFile, routeForFile } from '../route-for-file';
+import {
+  matrixRowForFile,
+  outputsForExt,
+  routeForFile,
+} from '../route-for-file';
 import { submitConversion } from '../submit-conversion';
 
 // ─────────────────────────────────────────────────────── HELPERS ─────────────
@@ -171,5 +175,118 @@ describe('SEAN-75 homepage drop — file is honoured without re-upload', () => {
     assert.ok(call);
     assert.equal(call.body.get('target_size_mb'), '25');
     assert.equal(call.body.get('crf'), '28');
+  });
+});
+
+describe('SEAN-79 outputsForExt — homepage format picker options', () => {
+  it('returns the full set of convert outputs for a .mov input', () => {
+    // Dropping a .mov should let the user pick mp4 (default), webm, mov, and
+    // any other convert-style row whose route is implemented today. The
+    // picker hides extract-audio / gif / compress — those are different
+    // intents, not different output formats of the convert intent.
+    const options = outputsForExt('mov');
+    assert.ok(options.length >= 2, 'expected at least 2 mov output options');
+
+    const formats = new Set<string>(options.map((o) => o.format));
+    assert.ok(formats.has('mp4'), 'mov picker must offer mp4');
+    assert.ok(formats.has('webm'), 'mov picker must offer webm');
+
+    // Extract-audio outputs (mp3/wav/aac/flac/ogg/opus) MUST NOT appear in
+    // the convert picker — they are a separate operation.
+    for (const audio of ['mp3', 'wav', 'aac', 'flac', 'ogg', 'opus']) {
+      assert.ok(
+        !formats.has(audio),
+        `mov picker must not surface audio output ${audio}`,
+      );
+    }
+    // Same for animated outputs (gif op, not convert).
+    for (const anim of ['gif', 'webp-anim']) {
+      assert.ok(
+        !formats.has(anim),
+        `mov picker must not surface animated output ${anim}`,
+      );
+    }
+  });
+
+  it('marks exactly one option as the default and sorts it first', () => {
+    const options = outputsForExt('mov');
+    const defaults = options.filter((o) => o.isDefault);
+    assert.equal(
+      defaults.length,
+      1,
+      'expected exactly one default option for .mov',
+    );
+    assert.equal(defaults[0]?.format, 'mp4', '.mov default must be mp4');
+    // Default first in the sorted list.
+    assert.equal(
+      options[0]?.format,
+      'mp4',
+      'default option must sort to the front',
+    );
+  });
+
+  it('agrees with matrixRowForFile on the default target row', () => {
+    // The picker default and the routeForFile preferred target must point at
+    // the same row — otherwise a user who never touches the picker gets a
+    // different target from someone who lands on the slug page directly.
+    const exts = ['mov', 'mp4', 'webm', 'mkv', 'png', 'heic'];
+    for (const ext of exts) {
+      const match = matrixRowForFile({ name: `a.${ext}` });
+      const options = outputsForExt(ext);
+      if (!match) {
+        // No match means no preferred target — picker may still have options
+        // but no `isDefault: true` entry.
+        const hasDefault = options.some((o) => o.isDefault);
+        assert.ok(
+          !hasDefault,
+          `outputsForExt('${ext}') flagged a default but matrixRowForFile returned null`,
+        );
+        continue;
+      }
+      const def = options.find((o) => o.isDefault);
+      assert.ok(def, `outputsForExt('${ext}') has no default option`);
+      assert.equal(
+        def.format,
+        match.row.outputFormat,
+        `picker default for .${ext} (${def.format}) does not match matrixRowForFile (${match.row.outputFormat})`,
+      );
+    }
+  });
+
+  it('returns empty array for an unknown extension', () => {
+    assert.deepEqual(outputsForExt(''), []);
+    assert.deepEqual(outputsForExt('xyz-not-real'), []);
+  });
+
+  it('every returned row has an implemented route', () => {
+    // Same gating as routeForFile / matrixRowForFile — clicking a chip must
+    // never land the user on a 404. We can't easily import route-registry's
+    // gate from here without the @/ alias, so cross-check by piping each
+    // row's slug through routeForFile (which uses the same gate).
+    for (const ext of ['mov', 'mp4', 'webm', 'png', 'heic']) {
+      const options = outputsForExt(ext);
+      for (const opt of options) {
+        // The row must at minimum exist + have a goOp the homepage can fire.
+        assert.ok(opt.row.slug, `option for .${ext} has empty slug`);
+        assert.ok(opt.row.goOp, `option for .${ext} has empty goOp`);
+        assert.ok(
+          opt.row.inputFormats.length > 0,
+          `option for .${ext} has empty inputFormats`,
+        );
+      }
+    }
+  });
+
+  it('does not duplicate output formats when multiple rows target the same one', () => {
+    // E.g. mov can resolve via the flagship `mov-to-mp4` row OR the
+    // multi-input `video-to-mp4` row — the picker should only show MP4 once.
+    const options = outputsForExt('mov');
+    const formats = options.map((o) => o.format);
+    const unique = new Set(formats);
+    assert.equal(
+      formats.length,
+      unique.size,
+      `outputsForExt('mov') returned duplicate formats: ${formats.join(', ')}`,
+    );
   });
 });

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -299,3 +299,102 @@ export function matrixInputExtensions(): string[] {
   }
   return [...exts].sort();
 }
+
+/**
+ * SEAN-79 — one available output format the picker can render. The picker on
+ * the homepage drop zone shows one chip per `OutputOption` returned here, so
+ * the user who drops a `.mov` and wants `.webm` instead of the preferred
+ * `.mp4` default can re-pick before the conversion fires.
+ */
+export interface OutputOption {
+  /** Resolved matrix row that runs the conversion if the user picks this format. */
+  row: OperationRow;
+  /** Output format enum (e.g. `mp4`, `webm`, `webp`). */
+  format: Format;
+  /** UI label (uppercase ext, e.g. `MP4`, `WEBM`, `JPG`). */
+  label: string;
+  /** True for the row `routeForFile`'s preferred-target table picks by default. */
+  isDefault: boolean;
+}
+
+/**
+ * SEAN-79 — every pure-format output the matrix supports for a given input
+ * extension. Used by the homepage format picker so the user can re-pick the
+ * output before clicking Convert.
+ *
+ * Scope is intentionally narrow: only `convert` and `image-convert` rows are
+ * returned (the picker's intent is "swap output format", not "switch
+ * operation"). Extract-audio, gif, compress, trim etc. live on dedicated slug
+ * pages and the homepage doesn't surface them via the picker — those are
+ * different intents, not different output formats of the same intent.
+ *
+ * Pure function of input ext + matrix — no API call, no side effects, safe to
+ * compute at module load. Empty array means the picker should be hidden.
+ */
+export function outputsForExt(ext: string): OutputOption[] {
+  if (!ext) return [];
+  const inputFormat = (EXT_TO_FORMAT[ext] ?? ext) as Format;
+  const preferredTarget = PREFERRED_TARGET_BY_EXT[ext];
+
+  // Map of outputFormat → chosen row. We dedupe by output format because two
+  // rows can target the same output (e.g. a flagship `mov-to-mp4` row plus
+  // the multi-input `video-to-mp4` fallback both produce mp4 from mov). The
+  // direct `${input}-to-${target}` slug wins over multi-input rows so the
+  // user lands on the page Google ranks for the pair.
+  const byOutput = new Map<Format, OperationRow>();
+
+  for (const row of MATRIX) {
+    if (row.operation !== 'convert' && row.operation !== 'image-convert') {
+      continue;
+    }
+    if (!row.inputFormats.includes(inputFormat)) continue;
+    if (!MATRIX_BY_SLUG[row.slug]) continue;
+    if (!routeExistsForSlug(row.slug)) continue;
+
+    const directSlug = `${inputFormat}-to-${formatExtName(row.outputFormat)}`;
+    const existing = byOutput.get(row.outputFormat);
+    if (!existing) {
+      byOutput.set(row.outputFormat, row);
+      continue;
+    }
+    // Prefer the direct `${input}-to-${output}` slug over a multi-input row.
+    if (row.slug === directSlug && existing.slug !== directSlug) {
+      byOutput.set(row.outputFormat, row);
+    }
+  }
+
+  const options: OutputOption[] = [];
+  for (const [format, row] of byOutput) {
+    options.push({
+      row,
+      format,
+      label: formatExtName(format).toUpperCase(),
+      isDefault: format === preferredTarget,
+    });
+  }
+
+  // Stable order: default first, then alphabetical by label.
+  options.sort((a, b) => {
+    if (a.isDefault && !b.isDefault) return -1;
+    if (!a.isDefault && b.isDefault) return 1;
+    return a.label.localeCompare(b.label);
+  });
+
+  return options;
+}
+
+/**
+ * Map a `Format` enum value to the file-extension form used in slugs and URLs.
+ * Mirrors `formatToExt` in `./converter-row-args.ts`; duplicated here to keep
+ * this module JSX-free and importable from tests without a tsx loader.
+ */
+function formatExtName(format: Format): string {
+  switch (format) {
+    case 'gif-static':
+      return 'gif';
+    case 'webp-anim':
+      return 'webp';
+    default:
+      return format;
+  }
+}


### PR DESCRIPTION
Closes #79

## Summary
- Adds an inline format picker (chip row, FlagshipPills-style) that appears after a file is dropped on the homepage. Default is the `routeForFile` preferred target; the user can re-pick before clicking Convert.
- Slug pages stay unchanged — they lock the format on the slug for SEO arrivals.
- New `outputsForExt(ext)` helper is a pure function of input ext + matrix (server-renderable, no API call). Scope is `convert` and `image-convert` rows only — extract-audio/gif/compress are different intents, not different output formats.
- Refactored `HeroDrop` into a 3-stage state machine: idle → picking (chip row + Convert) → running (auto-fires upload via `ConverterPanel.initialFile`).
- Drive-by fix to `matrixRowForFile`: now walks `image-convert` rows so PNG/HEIC drops resolve a default instead of error-ing.

## Test plan
- [x] `yarn test` (in `apps/ffmpeg-converter/web`) — 10 tests pass, including new `outputsForExt` coverage
- [x] `npx tsc --noEmit` clean
- [x] `yarn build` succeeds
- [ ] Manual: drop a `.mov`, verify MP4 highlighted, click WEBM, click Convert, see WebM produced
- [ ] Manual: visit `/convert/mov-to-mp4` directly, verify no picker appears (slug owns intent)
- [ ] Manual: drop `.png`, verify image-to-webp default + image-to-jpg as alternative