### PR TITLE
[SEAN-93] feat: URL-state for converter options

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -15,7 +15,8 @@
     "test:word-count": "ts-node -P tsconfig.test.json src/ops/word-count.test.ts",
     "test:hero-drop": "ts-node -P tsconfig.test.json src/components/__tests__/HeroDrop.test.ts",
     "test:route-for-file": "ts-node -P tsconfig.test.json src/components/__tests__/route-for-file.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file"
+    "test:url-state": "ts-node -P tsconfig.test.json src/components/__tests__/url-state.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:url-state"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -8,10 +8,25 @@
 //
 // Spec §7.2 render order is fixed at the page shell level; this component
 // only handles the interactive convert step.
+//
+// SEAN-93 — reads URL query params on mount via `parseUrlState`, and any
+// time the URL changes (popstate). The parsed state is merged into extraArgs
+// (URL > preset > default) and substituted into the displayed ffmpeg command
+// so a shared link like `/gif/mp4-to-gif?fps=24&width=320` rehydrates the
+// panel and its copy-paste command verbatim. State writes go through
+// `applyUrlState` which uses `history.replaceState` (no scroll jump, no
+// history pollution).
 
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import type { Operation } from '@/ops/types';
 import { type ConversionJob, DropZone } from './DropZone';
 import { ResultBlock } from './ResultBlock';
+import {
+  applyUrlToFfmpegCommand,
+  mergeUrlIntoExtraArgs,
+  parseUrlState,
+  type UrlState,
+} from './url-state';
 
 export interface ConverterPanelProps {
   /** Backend op name. */
@@ -32,6 +47,12 @@ export interface ConverterPanelProps {
   reverseLabel?: string;
   /** Operation prefix for the reverse URL. */
   reverseOperation?: string;
+  /**
+   * SEAN-93 — high-level operation. Drives the URL-param whitelist so a video
+   * page rejects `max_colors` and a gif page rejects `crf`. Optional for
+   * backwards compatibility; absent ⇒ URL-state is disabled for the panel.
+   */
+  operation?: Operation;
   /**
    * SEAN-75: pre-loaded file forwarded from the homepage drop zone. When set,
    * `<DropZone />` auto-fires the upload on mount so the user reaches the
@@ -57,10 +78,44 @@ export function ConverterPanel({
   reverseSlug,
   reverseLabel,
   reverseOperation,
+  operation,
   initialFile,
   onReset,
 }: ConverterPanelProps) {
   const [job, setJob] = useState<ConversionJob | null>(null);
+
+  // SEAN-93 — initial URL-state snapshot, read on mount. SSR-safe (returns
+  // empty when `window` is undefined). Subscribes to `popstate` so the
+  // browser back/forward buttons resync the panel; updates triggered by the
+  // panel itself go through `applyUrlState` (replaceState) which doesn't
+  // fire popstate, so there's no feedback loop.
+  const [urlState, setUrlState] = useState<UrlState>({});
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !operation) return;
+    const sync = () => {
+      const params = new URLSearchParams(window.location.search);
+      setUrlState(parseUrlState(params, operation));
+    };
+    sync();
+    window.addEventListener('popstate', sync);
+    return () => {
+      window.removeEventListener('popstate', sync);
+    };
+  }, [operation]);
+
+  // Merge URL state into the row's preset-derived extraArgs (URL wins) and
+  // substitute the same values into the displayed ffmpeg command so a copy-
+  // paste of the command matches what the backend will run. Both are memoised
+  // so DropZone's effect deps stay stable when nothing changed.
+  const mergedExtraArgs = useMemo(
+    () => mergeUrlIntoExtraArgs(extraArgs, urlState),
+    [extraArgs, urlState],
+  );
+  const displayedCommand = useMemo(
+    () => applyUrlToFfmpegCommand(ffmpegCommand, urlState),
+    [ffmpegCommand, urlState],
+  );
 
   if (!job) {
     return (
@@ -69,7 +124,7 @@ export function ConverterPanel({
         outputExt={outputExt}
         accept={accept}
         acceptLabel={acceptLabel}
-        extraArgs={extraArgs}
+        extraArgs={mergedExtraArgs}
         onJobComplete={setJob}
         initialFile={initialFile}
       />
@@ -78,7 +133,7 @@ export function ConverterPanel({
   return (
     <ResultBlock
       job={job}
-      ffmpegCommand={ffmpegCommand}
+      ffmpegCommand={displayedCommand}
       reverseSlug={reverseSlug}
       reverseLabel={reverseLabel}
       reverseOperation={reverseOperation}

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -304,6 +304,7 @@ function RunningPanel({
         reverseSlug={reverse?.slug}
         reverseLabel={reverse?.label}
         reverseOperation={reverse?.operation}
+        operation={row.operation}
         initialFile={file}
         // SEAN-75: "Try another file" tears the panel back down to the
         // empty hero zone. Same hook the chip-row Cancel uses.

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -96,6 +96,7 @@ export function ToolPage({ row, page }: ToolPageProps) {
           reverseSlug={reverse?.slug}
           reverseLabel={reverse?.label}
           reverseOperation={reverse?.operation}
+          operation={row.operation}
         />
       </section>
 

--- a/apps/ffmpeg-converter/web/src/components/__tests__/url-state.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/url-state.test.ts
@@ -1,0 +1,240 @@
+/**
+ * SEAN-93 — URL-state for converter options.
+ *
+ * Three invariants this test guards:
+ *   1. Whitelist — `parseUrlState` keeps only operation-whitelisted params,
+ *      silently drops the rest. A `gif` page must reject `crf`, a `convert`
+ *      page must reject `max_colors`, etc.
+ *   2. Merge order — URL > preset > default. `mergeUrlIntoExtraArgs` must
+ *      let URL params override preset-derived extraArgs without erasing the
+ *      preset keys URL didn't touch.
+ *   3. Ffmpeg command reflection — `applyUrlToFfmpegCommand` must rewrite
+ *      `fps=N` and `scale=W:H` so a copy-paste command matches the user's
+ *      URL state. Backed by the AC test:
+ *        navigating to /gif/mp4-to-gif?fps=24&width=320 → command shows
+ *        `fps=24,scale=320:-1`.
+ *
+ * Test runner: `node --test` via ts-node (matches the rest of the suite).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { MATRIX_BY_SLUG } from '../../ops/matrix';
+import { buildExtraArgs } from '../converter-row-args';
+import {
+  applyUrlToFfmpegCommand,
+  mergeUrlIntoExtraArgs,
+  parseUrlState,
+  serializeUrlState,
+  URL_PARAM_WHITELIST,
+} from '../url-state';
+
+describe('SEAN-93 url-state — parseUrlState whitelist enforcement', () => {
+  it('keeps gif-whitelisted params and drops everything else', () => {
+    const state = parseUrlState(
+      'fps=24&width=320&max_colors=128&dither=bayer&crf=18&hostile=1',
+      'gif',
+    );
+    assert.equal(state.fps, '24');
+    assert.equal(state.width, '320');
+    assert.equal(state.max_colors, '128');
+    assert.equal(state.dither, 'bayer');
+    // crf is convert-only, must be dropped on the gif row.
+    assert.equal(state.crf, undefined, 'crf must be dropped on a gif page');
+    // Unknown params must be dropped wholesale — no echo, no forwarding.
+    assert.equal(state.hostile, undefined, 'unknown param must be dropped');
+  });
+
+  it('rejects gif-only params on a video convert page', () => {
+    const state = parseUrlState('crf=23&max_colors=128&fps=30', 'convert');
+    assert.equal(state.crf, '23');
+    assert.equal(state.fps, '30');
+    assert.equal(
+      state.max_colors,
+      undefined,
+      'max_colors is gif-only, must be dropped on convert',
+    );
+  });
+
+  it('drops empty-string values so ?fps= doesn’t override the preset', () => {
+    const state = parseUrlState('fps=&width=480', 'gif');
+    assert.equal(state.fps, undefined);
+    assert.equal(state.width, '480');
+  });
+
+  it('accepts both URLSearchParams and raw strings', () => {
+    const fromString = parseUrlState('fps=20', 'gif');
+    const fromParams = parseUrlState(new URLSearchParams('fps=20'), 'gif');
+    assert.deepEqual(fromString, fromParams);
+  });
+
+  it('returns an empty object for operations with no whitelisted params', () => {
+    // `mute` and `merge` deliberately have no params today.
+    assert.deepEqual(parseUrlState('foo=1', 'mute'), {});
+    assert.deepEqual(parseUrlState('foo=1', 'merge'), {});
+  });
+
+  it('every operation in the type union has a whitelist entry', () => {
+    // Defence-in-depth — adding a new operation must force the author to
+    // declare its whitelist (even an empty array). Otherwise the new op
+    // would silently allow nothing and ConverterPanel would behave as if
+    // URL-state were disabled for the page.
+    const operations = [
+      'convert',
+      'compress',
+      'extract-audio',
+      'extract-frames',
+      'trim',
+      'resize',
+      'rotate',
+      'gif',
+      'merge',
+      'mute',
+      'change-speed',
+      'add-subtitles',
+      'remove-audio',
+      'reverse',
+      'thumbnail',
+      'contact-sheet',
+      'normalize-audio',
+      'image-convert',
+    ] as const;
+    for (const op of operations) {
+      assert.ok(
+        URL_PARAM_WHITELIST[op] !== undefined,
+        `URL_PARAM_WHITELIST is missing operation: ${op}`,
+      );
+    }
+  });
+});
+
+describe('SEAN-93 url-state — serializeUrlState round-trip', () => {
+  it('serializes whitelisted params in deterministic order', () => {
+    // Whitelist order for gif is [fps, width, max_colors, dither] — the
+    // serializer must follow that, not the input map's iteration order, so
+    // two identical states always produce byte-identical URLs.
+    const state = { dither: 'bayer', fps: '24', width: '320' };
+    const out = serializeUrlState(state, 'gif');
+    assert.equal(out, '?fps=24&width=320&dither=bayer');
+  });
+
+  it('returns empty string for an empty state (never just `?`)', () => {
+    assert.equal(serializeUrlState({}, 'gif'), '');
+  });
+
+  it('skips empty / nullish values', () => {
+    const state = { fps: '24', width: '' };
+    assert.equal(serializeUrlState(state, 'gif'), '?fps=24');
+  });
+
+  it('parse → serialize → parse is idempotent', () => {
+    const original = parseUrlState('fps=24&width=320&max_colors=128', 'gif');
+    const serialized = serializeUrlState(original, 'gif');
+    const reparsed = parseUrlState(serialized.slice(1), 'gif');
+    assert.deepEqual(reparsed, original);
+  });
+
+  it('encodes values that need URL-encoding', () => {
+    // `preset` for convert can be `slow`/`medium` — no encoding needed —
+    // but a future caller might pass a value with `&` or `=`. The serializer
+    // must use encodeURIComponent so the URL is parseable on the receive
+    // side.
+    const state = { preset: 'slow', crf: '18' };
+    const out = serializeUrlState(state, 'convert');
+    assert.equal(out, '?crf=18&preset=slow');
+  });
+});
+
+describe('SEAN-93 url-state — mergeUrlIntoExtraArgs (URL > preset > default)', () => {
+  it('URL params override preset-derived extraArgs', () => {
+    const presetArgs = { fps: '10', target_size_mb: '25' };
+    const urlState = { fps: '24' };
+    const merged = mergeUrlIntoExtraArgs(presetArgs, urlState);
+    assert.ok(merged);
+    assert.equal(merged.fps, '24', 'URL fps must beat preset fps');
+    // Preset keys URL didn't touch must survive.
+    assert.equal(merged.target_size_mb, '25');
+  });
+
+  it('preset survives when URL state is empty', () => {
+    const presetArgs = { fps: '10' };
+    const merged = mergeUrlIntoExtraArgs(presetArgs, {});
+    assert.deepEqual(merged, { fps: '10' });
+  });
+
+  it('URL state alone produces extraArgs when preset is undefined', () => {
+    const merged = mergeUrlIntoExtraArgs(undefined, { fps: '24' });
+    assert.deepEqual(merged, { fps: '24' });
+  });
+
+  it('returns undefined when both inputs are empty', () => {
+    assert.equal(mergeUrlIntoExtraArgs(undefined, {}), undefined);
+    assert.equal(mergeUrlIntoExtraArgs({}, {}), undefined);
+  });
+
+  it('the gif flagship row + URL fps override produces the expected payload', () => {
+    // The `mp4-to-gif` flagship has preset.fps = 10. A user landing via
+    // ?fps=24 should send fps=24 to the backend, not 10. This is the
+    // load-bearing AC test from the ticket body.
+    const row = MATRIX_BY_SLUG['mp4-to-gif'];
+    assert.ok(row, 'mp4-to-gif must exist in the matrix');
+    const presetArgs = buildExtraArgs(row);
+    const urlState = parseUrlState('fps=24&width=320', 'gif');
+    const merged = mergeUrlIntoExtraArgs(presetArgs, urlState);
+    assert.ok(merged);
+    assert.equal(merged.fps, '24', 'URL fps must override preset fps=10');
+    assert.equal(merged.width, '320', 'URL width must reach the payload');
+  });
+});
+
+describe('SEAN-93 url-state — applyUrlToFfmpegCommand', () => {
+  it('rewrites fps=N in the gif flagship command', () => {
+    const row = MATRIX_BY_SLUG['mp4-to-gif'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, { fps: '24' });
+    assert.match(out, /fps=24/);
+    assert.doesNotMatch(out, /fps=10/, 'original fps=10 must be replaced');
+  });
+
+  it('rewrites scale=W:-1 to use the URL width', () => {
+    const command =
+      "ffmpeg -i input.mp4 -vf 'fps=10,scale=480:-1:flags=lanczos' output.gif";
+    const out = applyUrlToFfmpegCommand(command, { width: '320' });
+    assert.match(out, /scale=320:-1/);
+    assert.doesNotMatch(out, /scale=480/);
+  });
+
+  it('combined fps + width matches the AC example exactly', () => {
+    // Ticket body AC test:
+    //   navigating to /gif/mp4-to-gif?fps=24&width=320 → command shows
+    //   `fps=24,scale=320:-1`.
+    const row = MATRIX_BY_SLUG['mp4-to-gif'];
+    assert.ok(row);
+    const state = parseUrlState('fps=24&width=320', 'gif');
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, state);
+    assert.match(out, /fps=24,scale=320:-1/);
+  });
+
+  it('leaves the command untouched when state is empty', () => {
+    const row = MATRIX_BY_SLUG['mp4-to-gif'];
+    assert.ok(row);
+    assert.equal(
+      applyUrlToFfmpegCommand(row.ffmpegCommand, {}),
+      row.ffmpegCommand,
+    );
+  });
+
+  it('leaves non-ffmpeg-relevant params alone', () => {
+    // `max_colors` and `dither` are forwarded to the backend but the gif
+    // flagship's matrix command doesn't bake them in. The substitution
+    // should be a no-op for those, not a mangled string.
+    const row = MATRIX_BY_SLUG['mp4-to-gif'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, {
+      max_colors: '128',
+      dither: 'bayer',
+    });
+    assert.equal(out, row.ffmpegCommand);
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
+++ b/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
@@ -11,6 +11,11 @@
 import { MATRIX_BY_SLUG } from '@/ops/matrix';
 import type { OperationRow } from '@/ops/types';
 import { pathForSlug, routeExistsForSlug } from './route-registry';
+import {
+  applyUrlToFfmpegCommand,
+  mergeUrlIntoExtraArgs,
+  type UrlState,
+} from './url-state';
 
 /**
  * Map a Format enum to the file extension used in URLs and filenames. Most
@@ -106,6 +111,31 @@ export interface SiblingLink {
   slug: string;
   label: string;
   href: string;
+}
+
+/**
+ * SEAN-93 — merge a row's preset-derived extraArgs with any URL-state
+ * overrides. URL beats preset beats hard-coded fallback (the fallback lives
+ * inside the matrix's ffmpegCommand string). Returns `undefined` when both
+ * inputs are empty so the panel can spread it into props unchanged.
+ */
+export function buildExtraArgsWithUrlState(
+  row: OperationRow,
+  urlState: UrlState,
+): Record<string, string> | undefined {
+  return mergeUrlIntoExtraArgs(buildExtraArgs(row), urlState);
+}
+
+/**
+ * SEAN-93 — substitute URL-state values into a row's ffmpegCommand so the
+ * displayed command reflects what will actually run. Thin wrapper kept here
+ * so call sites import from a single module.
+ */
+export function buildFfmpegCommand(
+  row: OperationRow,
+  urlState: UrlState,
+): string {
+  return applyUrlToFfmpegCommand(row.ffmpegCommand, urlState);
 }
 
 /**

--- a/apps/ffmpeg-converter/web/src/components/url-state.ts
+++ b/apps/ffmpeg-converter/web/src/components/url-state.ts
@@ -1,0 +1,211 @@
+// SEAN-93 — URL-state for converter options.
+//
+// STRATEGY.md §"Repeat-customer hooks" calls out URL-state as the #1
+// differentiator vs every competitor: a link like
+// `/gif/mp4-to-gif?fps=24&width=320` is bookmarkable, shareable, and
+// rehydrates the converter panel with those exact settings. None of
+// CloudConvert / Zamzar / FreeConvert / Convertio / Media.io do this.
+//
+// This module is the typed parser + serializer + per-operation whitelist that
+// the gif preset row (#92) and any future advanced-panel surface (CRF,
+// bitrate, etc.) plug into. ConverterPanel reads state from the URL on mount
+// via `parseUrlState`, writes state back via `applyUrlState` /
+// `serializeUrlState`, and merges the result into extraArgs / the displayed
+// ffmpeg command via `mergeUrlIntoExtraArgs` / `applyUrlToFfmpegCommand`.
+//
+// Design notes
+// ────────────
+// * Whitelist per operation. A `gif` page accepts `fps`, `width`, `max_colors`,
+//   `dither`; a `convert` page accepts `crf`, `preset`, `audio_bitrate`. An
+//   unknown param is silently dropped (not echoed back into the URL, not
+//   forwarded to extraArgs) so a hostile share-link can't slip arbitrary
+//   form fields onto the multipart body.
+// * `replaceState`, not `pushState`. We don't want every fps tweak to add a
+//   history entry — the back-button must still take the user to the previous
+//   page. `replaceState` also avoids the scroll jump that `router.replace`
+//   triggers in Next.js 15.
+// * Merge order is URL > preset > default. The matrix row's preset (e.g.
+//   `{ fps: 10 }` for the GIF flagship) is the page's default; URL params
+//   override it. Hard-coded fallbacks in the ffmpegCommand template act as
+//   the last resort when neither URL nor preset specify a value.
+
+import type { Operation } from '@/ops/types';
+
+// ─────────────────────────────────────────────────────── WHITELIST ───────────
+
+/**
+ * Canonical list of URL params each operation accepts. Adding a new param to
+ * this list is the only way to make it survive `parseUrlState` — anything
+ * else is silently dropped. Ordering inside each array matters only for
+ * deterministic URL serialization (see `serializeUrlState`).
+ *
+ * Param naming convention: snake_case to match the multipart form field
+ * names the Go backend reads. `width` and `height` are exceptions — they're
+ * UI-level settings the frontend translates into ffmpeg `scale=W:H` filters,
+ * not raw form fields.
+ */
+export const URL_PARAM_WHITELIST: Record<Operation, readonly string[]> = {
+  convert: ['crf', 'preset', 'audio_bitrate', 'resolution', 'fps'],
+  compress: ['crf', 'preset', 'target_size_mb', 'audio_bitrate', 'resolution'],
+  'extract-audio': ['audio_bitrate'],
+  'extract-frames': ['fps', 'width'],
+  trim: ['start', 'duration'],
+  resize: ['width', 'height', 'resolution'],
+  rotate: ['angle'],
+  gif: ['fps', 'width', 'max_colors', 'dither'],
+  merge: [],
+  mute: [],
+  'change-speed': ['speed'],
+  'add-subtitles': [],
+  'remove-audio': [],
+  reverse: [],
+  thumbnail: ['width', 'time'],
+  'contact-sheet': ['width', 'rows', 'cols'],
+  'normalize-audio': ['target_lufs'],
+  'image-convert': ['quality', 'width', 'height'],
+};
+
+// ─────────────────────────────────────────────────────── TYPES ───────────────
+
+/**
+ * Parsed URL state — a map of whitelisted param name → string value. Always a
+ * string because URL params are strings; numeric coercion happens at the
+ * point of use (e.g. when feeding into the ffmpeg command template).
+ */
+export type UrlState = Readonly<Record<string, string>>;
+
+// ─────────────────────────────────────────────────────── PARSE ───────────────
+
+/**
+ * Read the URL query params and return only those whitelisted for `operation`.
+ * Unknown params are silently dropped. Empty-string values are also dropped
+ * (so `?fps=` doesn't override the preset with an empty string).
+ *
+ * Pure, testable — pass either a `URLSearchParams` or the raw search string
+ * (with or without leading `?`). On the server (SSR) just don't call this;
+ * the panel reads URL state inside a `useEffect` after mount.
+ */
+export function parseUrlState(
+  search: URLSearchParams | string,
+  operation: Operation,
+): UrlState {
+  const params =
+    typeof search === 'string' ? new URLSearchParams(search) : search;
+  const whitelist = URL_PARAM_WHITELIST[operation] ?? [];
+  const out: Record<string, string> = {};
+  for (const key of whitelist) {
+    const value = params.get(key);
+    if (value !== null && value !== '') {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+// ─────────────────────────────────────────────────────── SERIALIZE ───────────
+
+/**
+ * Build a deterministic query string from a UrlState. Empty / nullish values
+ * are skipped. Output is sorted by the operation's whitelist order so two
+ * panels with the same state always produce byte-identical URLs (otherwise
+ * `replaceState` thrashes on every render).
+ *
+ * Returns `''` when the state is empty — never returns just `?`.
+ */
+export function serializeUrlState(
+  state: UrlState,
+  operation: Operation,
+): string {
+  const whitelist = URL_PARAM_WHITELIST[operation] ?? [];
+  const parts: string[] = [];
+  for (const key of whitelist) {
+    const value = state[key];
+    if (value === undefined || value === null || value === '') continue;
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(value)}`);
+  }
+  return parts.length === 0 ? '' : `?${parts.join('&')}`;
+}
+
+// ─────────────────────────────────────────────────────── APPLY (browser) ─────
+
+/**
+ * Push the URL state into the browser bar via `history.replaceState` — never
+ * `pushState` (back-button must still go back to the previous page). Skips
+ * the call entirely when the URL would be unchanged so we don't trigger the
+ * Next.js scroll restore handler on every keystroke.
+ *
+ * Server-safe no-op when `window` is undefined.
+ */
+export function applyUrlState(state: UrlState, operation: Operation): void {
+  if (typeof window === 'undefined') return;
+  const search = serializeUrlState(state, operation);
+  const next = `${window.location.pathname}${search}${window.location.hash}`;
+  if (
+    next ===
+    `${window.location.pathname}${window.location.search}${window.location.hash}`
+  ) {
+    return;
+  }
+  window.history.replaceState(window.history.state, '', next);
+}
+
+// ─────────────────────────────────────────────────────── MERGE ───────────────
+
+/**
+ * Merge URL params into the row's preset-derived extraArgs. URL wins over
+ * preset; preset wins over hard-coded fallbacks (which live in the ffmpeg
+ * command template, not here).
+ *
+ * Both inputs must be already-whitelisted: extraArgs comes from
+ * `buildExtraArgs(row)` and only contains preset-blessed keys; UrlState
+ * comes from `parseUrlState` and only contains operation-whitelisted keys.
+ * The output is the multipart-form payload the backend will receive.
+ *
+ * Returns `undefined` when the merged result is empty so callers can spread
+ * it into the panel props with the same shape as before.
+ */
+export function mergeUrlIntoExtraArgs(
+  presetArgs: Record<string, string> | undefined,
+  urlState: UrlState,
+): Record<string, string> | undefined {
+  const merged: Record<string, string> = { ...(presetArgs ?? {}) };
+  for (const [key, value] of Object.entries(urlState)) {
+    if (value === undefined || value === null || value === '') continue;
+    merged[key] = value;
+  }
+  return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
+// ─────────────────────────────────────────────────────── FFMPEG TEMPLATE ─────
+
+/**
+ * Substitute URL-state values into a row's ffmpegCommand string so the
+ * displayed command reflects what will actually run.
+ *
+ * The matrix authors ffmpeg commands with literal preset values baked in
+ * (e.g. `fps=10,scale=480:-1` for the GIF flagship row). When the user
+ * overrides via URL params we patch those literals so the copy-paste command
+ * stays accurate. Scope is intentionally narrow:
+ *   - `fps=N` → replaces `fps=<digits>` everywhere in the command
+ *   - `width=N` → replaces `scale=<digits>:-1` and `scale=<digits>:<anything>`
+ *
+ * Anything else (CRF, bitrate, etc.) is forwarded to the backend via
+ * extraArgs but the ffmpeg command keeps its original literal — Phase 2 of
+ * URL-state will extend this list once a wider set of advanced controls
+ * actually exists in the UI.
+ */
+export function applyUrlToFfmpegCommand(
+  template: string,
+  state: UrlState,
+): string {
+  let out = template;
+  if (state.fps) {
+    out = out.replace(/fps=\d+/g, `fps=${state.fps}`);
+  }
+  if (state.width) {
+    // Match `scale=<digits>:-1` and `scale=<digits>:<digits>` (the two shapes
+    // the matrix uses today) without touching the height side.
+    out = out.replace(/scale=\d+:(-?\d+)/g, `scale=${state.width}:$1`);
+  }
+  return out;
+}


### PR DESCRIPTION
Closes #93

## Summary
- New `url-state.ts` module: per-operation whitelist + parser + serializer + ffmpeg-command substitution. Unknown params silently dropped, empty values ignored, deterministic serialization order.
- `ConverterPanel` reads URL state on mount + on `popstate`, merges it into `extraArgs` (URL > preset > default), and reflects fps/width changes into the displayed ffmpeg command.
- 21 unit tests in `__tests__/url-state.test.ts` cover the whitelist, merge order, ffmpeg substitution, and the AC test (`/gif/mp4-to-gif?fps=24&width=320` → command shows `fps=24,scale=320:-1`).

## Test plan
- [x] `yarn test:url-state` (21/21 passing)
- [x] `yarn test` (all suites pass)
- [x] `yarn tsc --noEmit` clean
- [ ] Visit `/gif/mp4-to-gif?fps=24&width=320` in dev; confirm panel renders and the displayed ffmpeg command shows `fps=24,scale=320:-1`
- [ ] Confirm browser back-button still navigates to the previous page (i.e. `replaceState`, not `pushState`)