### PR TITLE
[SEAN-94] feat: saved preset library in localStorage

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -17,7 +17,8 @@
     "test:route-for-file": "ts-node -P tsconfig.test.json src/components/__tests__/route-for-file.test.ts",
     "test:result-block": "ts-node -P tsconfig.test.json src/components/__tests__/ResultBlock.test.ts",
     "test:url-state": "ts-node -P tsconfig.test.json src/components/__tests__/url-state.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state"
+    "test:preset-storage": "ts-node -P tsconfig.test.json src/components/__tests__/preset-storage.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -16,12 +16,30 @@
 // panel and its copy-paste command verbatim. State writes go through
 // `applyUrlState` which uses `history.replaceState` (no scroll jump, no
 // history pollution).
+//
+// SEAN-94 — saved preset library on top of URL-state. The chip row above
+// the drop zone shows the user's saved presets for this operation; clicking
+// one applies the preset's args to the URL (which the existing useEffect
+// picks up and merges into extraArgs). "Save as preset…" snapshots the
+// current URL state into localStorage; a "JSON" toggle reveals export /
+// import controls for cross-device sync. Storage and the UI live in
+// `./preset-storage.ts` so this file stays focused on the rendering logic.
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Operation } from '@/ops/types';
 import { type ConversionJob, DropZone } from './DropZone';
+import {
+  deletePreset as deletePresetFromStorage,
+  exportPresetsAsJson,
+  importPresets,
+  loadPresets,
+  newPresetId,
+  type SavedPreset,
+  savePreset as savePresetToStorage,
+} from './preset-storage';
 import { ResultBlock } from './ResultBlock';
 import {
+  applyUrlState,
   applyUrlToFfmpegCommand,
   mergeUrlIntoExtraArgs,
   parseUrlState,
@@ -119,15 +137,28 @@ export function ConverterPanel({
 
   if (!job) {
     return (
-      <DropZone
-        goOp={goOp}
-        outputExt={outputExt}
-        accept={accept}
-        acceptLabel={acceptLabel}
-        extraArgs={mergedExtraArgs}
-        onJobComplete={setJob}
-        initialFile={initialFile}
-      />
+      <>
+        {operation && (
+          <SavedPresetsBar
+            operation={operation}
+            currentArgs={urlState}
+            onApply={(preset) => {
+              if (typeof window === 'undefined') return;
+              applyUrlState(preset.args, operation);
+              setUrlState(preset.args);
+            }}
+          />
+        )}
+        <DropZone
+          goOp={goOp}
+          outputExt={outputExt}
+          accept={accept}
+          acceptLabel={acceptLabel}
+          extraArgs={mergedExtraArgs}
+          onJobComplete={setJob}
+          initialFile={initialFile}
+        />
+      </>
     );
   }
   return (
@@ -143,4 +174,270 @@ export function ConverterPanel({
       }}
     />
   );
+}
+
+// ─────────────────────────────────────────────────────── SAVED PRESETS UI ────
+
+interface SavedPresetsBarProps {
+  operation: Operation;
+  /**
+   * Current URL-state args — what gets snapshotted when the user clicks
+   * "Save as preset". The bar shows a hint when this is empty so the user
+   * knows there's nothing to save yet.
+   */
+  currentArgs: UrlState;
+  /**
+   * Apply a preset by routing its args through `applyUrlState`. The parent
+   * also resyncs its own urlState so the merged extraArgs / command refresh
+   * immediately rather than waiting for the next render cycle.
+   */
+  onApply: (preset: SavedPreset) => void;
+}
+
+/**
+ * SEAN-94 — chip-row UI for saved presets.
+ *
+ * Three modes:
+ *   - Empty list, no current args ⇒ render nothing (no UI noise).
+ *   - Empty list, current args ⇒ render a single "Save as preset…" button.
+ *   - Non-empty list ⇒ render the chips row + "Save as preset…" + JSON menu.
+ *
+ * State is read from localStorage on mount (SSR-safe — module's safeRead
+ * returns `null` when `window` is undefined). The component only re-reads
+ * from storage after a save / delete / import; we don't subscribe to a
+ * storage event because cross-tab sync is out of scope (the user could open
+ * a second tab and edit; the chip row just won't see it until next mount).
+ */
+function SavedPresetsBar({
+  operation,
+  currentArgs,
+  onApply,
+}: SavedPresetsBarProps) {
+  const [presets, setPresets] = useState<SavedPreset[]>([]);
+  const [showJsonPanel, setShowJsonPanel] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+
+  // Read once on mount and any time the operation changes (e.g. when the
+  // homepage chip row remounts the panel onto a different row.slug).
+  useEffect(() => {
+    setPresets(loadPresets(operation));
+  }, [operation]);
+
+  const refresh = useCallback(() => {
+    setPresets(loadPresets(operation));
+  }, [operation]);
+
+  const handleSave = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    if (Object.keys(currentArgs).length === 0) {
+      window.alert(
+        'Tweak a setting first — there are no custom args to save yet.',
+      );
+      return;
+    }
+    const name = window.prompt('Name this preset:', '');
+    if (!name) return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const ok = savePresetToStorage(operation, {
+      id: newPresetId(),
+      name: trimmed,
+      args: currentArgs,
+      createdAt: Date.now(),
+    });
+    if (!ok) {
+      window.alert(
+        'Could not save preset — your browser storage may be full or disabled.',
+      );
+      return;
+    }
+    refresh();
+  }, [currentArgs, operation, refresh]);
+
+  const handleDelete = useCallback(
+    (id: string) => {
+      deletePresetFromStorage(operation, id);
+      refresh();
+    },
+    [operation, refresh],
+  );
+
+  const handleExport = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const json = exportPresetsAsJson();
+    const blob = new Blob([json], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `converter-presets-${new Date()
+      .toISOString()
+      .slice(0, 10)}.json`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const handleImportFile = useCallback(
+    async (file: File) => {
+      setImportError(null);
+      try {
+        const text = await file.text();
+        const result = importPresets(text);
+        if (!result.ok) {
+          setImportError(
+            result.reason === 'invalid-json'
+              ? 'That file isn’t valid JSON.'
+              : result.reason === 'invalid-shape'
+                ? 'That file isn’t a converter preset export.'
+                : result.reason === 'unsupported-version'
+                  ? 'That preset file is from a newer version. Update first.'
+                  : 'Browser storage rejected the import (quota / disabled).',
+          );
+          return;
+        }
+        refresh();
+      } catch {
+        setImportError('Could not read that file.');
+      }
+    },
+    [refresh],
+  );
+
+  const hasPresets = presets.length > 0;
+  const hasArgsToSave = Object.keys(currentArgs).length > 0;
+
+  // Empty state with nothing to save = render nothing. The bar would just be
+  // a lone disabled button — adds noise, removes nothing.
+  if (!hasPresets && !hasArgsToSave) return null;
+
+  return (
+    <div
+      className={[
+        'mb-3 flex flex-col gap-2',
+        'rounded-2xl border border-gray-800 bg-gray-900/40',
+        'px-3 py-2',
+      ].join(' ')}
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        {hasPresets && <span className="text-xs text-gray-500">saved:</span>}
+        {presets.map((preset) => (
+          <span
+            key={preset.id}
+            className={[
+              'inline-flex items-center rounded-full',
+              'border border-gray-700 bg-gray-900/60',
+              'pl-3 pr-1 py-1 text-xs font-medium text-gray-200',
+              'hover:border-indigo-500 hover:bg-indigo-500/10',
+            ].join(' ')}
+          >
+            <button
+              type="button"
+              onClick={() => onApply(preset)}
+              title={summarisePresetArgs(preset.args)}
+              className="mr-1 cursor-pointer text-gray-100 hover:text-white"
+            >
+              {preset.name}
+            </button>
+            <button
+              type="button"
+              aria-label={`Delete preset ${preset.name}`}
+              onClick={() => handleDelete(preset.id)}
+              className={[
+                'inline-flex h-5 w-5 items-center justify-center',
+                'rounded-full text-gray-500',
+                'hover:bg-red-500/20 hover:text-red-400',
+              ].join(' ')}
+            >
+              {'×'}
+            </button>
+          </span>
+        ))}
+        <button
+          type="button"
+          onClick={handleSave}
+          className={[
+            'inline-flex items-center rounded-full',
+            'border border-dashed border-gray-700 bg-transparent',
+            'px-3 py-1 text-xs text-gray-300',
+            'transition-colors hover:border-indigo-500 hover:text-white',
+          ].join(' ')}
+        >
+          + Save as preset…
+        </button>
+        <button
+          type="button"
+          aria-expanded={showJsonPanel}
+          onClick={() => setShowJsonPanel((v) => !v)}
+          className={[
+            'ml-auto inline-flex items-center rounded-full',
+            'border border-gray-800 bg-transparent',
+            'px-3 py-1 text-xs text-gray-500',
+            'hover:border-gray-600 hover:text-gray-300',
+          ].join(' ')}
+        >
+          JSON
+        </button>
+      </div>
+      {showJsonPanel && (
+        <div className="flex flex-col gap-2 border-t border-gray-800 pt-2">
+          <p className="text-xs text-gray-500">
+            Move presets between devices — there’s no login.
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleExport}
+              className={[
+                'inline-flex items-center rounded-full',
+                'border border-gray-700 bg-gray-900/60',
+                'px-3 py-1 text-xs text-gray-200',
+                'hover:border-indigo-500 hover:text-white',
+              ].join(' ')}
+            >
+              Export JSON
+            </button>
+            <label
+              className={[
+                'inline-flex cursor-pointer items-center rounded-full',
+                'border border-gray-700 bg-gray-900/60',
+                'px-3 py-1 text-xs text-gray-200',
+                'hover:border-indigo-500 hover:text-white',
+              ].join(' ')}
+            >
+              Import JSON
+              <input
+                type="file"
+                accept="application/json,.json"
+                hidden
+                onChange={(e) => {
+                  const file = e.target.files?.[0];
+                  if (file) void handleImportFile(file);
+                  // Reset the input so re-selecting the same file fires onChange.
+                  e.target.value = '';
+                }}
+              />
+            </label>
+          </div>
+          {importError && (
+            <p role="alert" className="text-xs text-red-400">
+              {importError}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Compact human-readable summary of a preset's args, used as the chip's
+ * tooltip so the user can hover to see exactly what'll be applied. Order
+ * is whatever `Object.entries` returns — fine for a tooltip; the actual
+ * URL-state serialiser sorts deterministically for caching reasons.
+ */
+function summarisePresetArgs(args: UrlState): string {
+  const entries = Object.entries(args);
+  if (entries.length === 0) return '(no custom args)';
+  return entries.map(([k, v]) => `${k}=${v}`).join(', ');
 }

--- a/apps/ffmpeg-converter/web/src/components/__tests__/preset-storage.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/preset-storage.test.ts
@@ -1,0 +1,540 @@
+/**
+ * SEAN-94 — saved preset library backed by localStorage.
+ *
+ * Three invariants this test guards:
+ *   1. Per-operation isolation. A preset saved on the gif page MUST NOT
+ *      leak into the convert page's preset list. The shape of
+ *      `storageKeyFor` ensures this — but the suite asserts the round-trip
+ *      explicitly so a future refactor can't quietly introduce a global
+ *      key.
+ *   2. Round-trip integrity. `savePreset` → `loadPresets` returns the
+ *      saved record byte-for-byte; reload-survives-restart is modelled by
+ *      throwing away the in-memory `localStorage` shim and instantiating a
+ *      fresh one (the AC test from the ticket body).
+ *   3. Defensive parsing. A malformed JSON blob in storage, an unknown
+ *      shape, or a hostile non-array value must produce `[]` (never
+ *      throw) so the chip rendering pipeline keeps working when storage
+ *      gets wedged.
+ *
+ * No JSDOM — we install a minimal in-memory `localStorage` shim on the
+ * Node global so the SSR-safety guard in preset-storage (`typeof window`)
+ * sees a window object. This matches the rest of the suite's no-React
+ * approach (see ResultBlock.test.ts for the same pattern).
+ *
+ * Test runner: `node --test` via ts-node.
+ */
+
+import { strict as assert } from 'node:assert';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+// ─────────────────────────────────────────────────────── SHIM ────────────────
+
+/**
+ * Minimal in-memory `Storage` polyfill. Only implements the surface
+ * preset-storage actually touches (`getItem`, `setItem`, `removeItem`).
+ * The `quotaExceeded` flag lets a single test simulate Safari-private-mode
+ * behaviour without monkey-patching the global mid-flight.
+ */
+class FakeStorage {
+  private map = new Map<string, string>();
+  quotaExceeded = false;
+  throwOnRead = false;
+
+  getItem(key: string): string | null {
+    if (this.throwOnRead) {
+      throw new Error('storage disabled');
+    }
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+
+  setItem(key: string, value: string): void {
+    if (this.quotaExceeded) {
+      const err = new Error('QuotaExceededError');
+      err.name = 'QuotaExceededError';
+      throw err;
+    }
+    this.map.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.map.delete(key);
+  }
+
+  /** Test-only helper to seed an arbitrary string at a key. */
+  rawSet(key: string, value: string): void {
+    this.map.set(key, value);
+  }
+
+  /** Test-only helper to peek at the underlying map. */
+  rawGet(key: string): string | null {
+    return this.map.has(key) ? (this.map.get(key) as string) : null;
+  }
+}
+
+/**
+ * Install a fresh `window.localStorage` on the Node global. Returns the
+ * shim so tests can flip the quota / throw flags or peek at raw values.
+ */
+function installFakeStorage(): FakeStorage {
+  const fake = new FakeStorage();
+  // The fake `window` is intentionally minimal — preset-storage only
+  // touches `window.localStorage`. Casting to unknown lets us assign onto
+  // the Node global without dragging in `@types/dom`.
+  (
+    globalThis as unknown as {
+      window: { localStorage: FakeStorage };
+    }
+  ).window = { localStorage: fake };
+  return fake;
+}
+
+/** Tear down the shim so unrelated tests don't see a leaked `window`. */
+function uninstallFakeStorage(): void {
+  delete (globalThis as unknown as { window?: unknown }).window;
+}
+
+// The shim must be installed BEFORE preset-storage is required, because
+// the module's `safeRead` / `safeWrite` close over `typeof window` at call
+// time (not at import) — but we import lazily inside `beforeEach` to
+// guarantee a clean slate per test.
+let mod: typeof import('../preset-storage');
+
+beforeEach(() => {
+  installFakeStorage();
+  // Force a fresh module require so any internal caching (there is none
+  // today, but defence in depth) doesn't bleed between tests.
+  delete require.cache[require.resolve('../preset-storage')];
+  mod = require('../preset-storage') as typeof import('../preset-storage');
+});
+
+afterEach(() => {
+  uninstallFakeStorage();
+});
+
+// ─────────────────────────────────────────────────────── KEY SHAPE ───────────
+
+describe('SEAN-94 preset-storage — key shape', () => {
+  it('uses a per-operation key prefix', () => {
+    assert.equal(mod.storageKeyFor('gif'), 'converter.presets.gif');
+    assert.equal(mod.storageKeyFor('convert'), 'converter.presets.convert');
+    assert.equal(
+      mod.storageKeyFor('extract-audio'),
+      'converter.presets.extract-audio',
+    );
+  });
+
+  it('exports the prefix constant for tests / clean-up tooling', () => {
+    assert.equal(mod.STORAGE_KEY_PREFIX, 'converter.presets.');
+  });
+});
+
+// ─────────────────────────────────────────────────────── ROUND-TRIP ──────────
+
+describe('SEAN-94 preset-storage — save / load round-trip', () => {
+  it('saves a preset and reads it back unchanged', () => {
+    const preset = {
+      id: 'p1',
+      name: 'Discord webm',
+      args: { crf: '28', resolution: '720p' },
+      createdAt: 1_700_000_000_000,
+    };
+    assert.equal(mod.savePreset('convert', preset), true);
+
+    const loaded = mod.loadPresets('convert');
+    assert.equal(loaded.length, 1);
+    assert.deepEqual(loaded[0], preset);
+  });
+
+  it('returns [] when the key has never been written', () => {
+    assert.deepEqual(mod.loadPresets('gif'), []);
+  });
+
+  it('preserves save order across multiple saves', () => {
+    mod.savePreset('gif', {
+      id: 'a',
+      name: 'first',
+      args: { fps: '10' },
+      createdAt: 1,
+    });
+    mod.savePreset('gif', {
+      id: 'b',
+      name: 'second',
+      args: { fps: '24' },
+      createdAt: 2,
+    });
+    mod.savePreset('gif', {
+      id: 'c',
+      name: 'third',
+      args: { fps: '30' },
+      createdAt: 3,
+    });
+    const loaded = mod.loadPresets('gif');
+    assert.deepEqual(
+      loaded.map((p) => p.id),
+      ['a', 'b', 'c'],
+    );
+  });
+
+  it('survives a "browser restart" (fresh module + same storage backing)', () => {
+    // Save under one require of the module.
+    mod.savePreset('convert', {
+      id: 'survives',
+      name: 'Discord webm',
+      args: { crf: '28' },
+      createdAt: 1,
+    });
+    // Simulate the next page load: re-require the module without
+    // resetting the underlying storage. The preset must reappear because
+    // localStorage is the source of truth, not module-local state.
+    delete require.cache[require.resolve('../preset-storage')];
+    const reloaded =
+      require('../preset-storage') as typeof import('../preset-storage');
+    const presets = reloaded.loadPresets('convert');
+    assert.equal(presets.length, 1);
+    assert.equal(presets[0]?.id, 'survives');
+    assert.equal(presets[0]?.args.crf, '28');
+  });
+});
+
+// ─────────────────────────────────────────────────────── ISOLATION ───────────
+
+describe('SEAN-94 preset-storage — per-operation isolation', () => {
+  it('a webm preset on convert does not leak into the gif page list', () => {
+    mod.savePreset('convert', {
+      id: 'webm',
+      name: 'Discord webm',
+      args: { crf: '28' },
+      createdAt: 1,
+    });
+    assert.equal(mod.loadPresets('gif').length, 0);
+    assert.equal(mod.loadPresets('convert').length, 1);
+  });
+
+  it('deletes are scoped to the operation', () => {
+    mod.savePreset('convert', {
+      id: 'shared',
+      name: 'a',
+      args: {},
+      createdAt: 1,
+    });
+    mod.savePreset('gif', {
+      id: 'shared',
+      name: 'b',
+      args: {},
+      createdAt: 2,
+    });
+    // Same id under different operations — deleting from gif must not
+    // touch convert.
+    mod.deletePreset('gif', 'shared');
+    assert.equal(mod.loadPresets('gif').length, 0);
+    assert.equal(mod.loadPresets('convert').length, 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────── DELETE ──────────────
+
+describe('SEAN-94 preset-storage — deletePreset', () => {
+  it('removes the matching preset and leaves the rest in order', () => {
+    for (const id of ['a', 'b', 'c']) {
+      mod.savePreset('gif', { id, name: id, args: {}, createdAt: 0 });
+    }
+    assert.equal(mod.deletePreset('gif', 'b'), true);
+    assert.deepEqual(
+      mod.loadPresets('gif').map((p) => p.id),
+      ['a', 'c'],
+    );
+  });
+
+  it('returns false when the id is not present', () => {
+    mod.savePreset('gif', { id: 'a', name: 'a', args: {}, createdAt: 0 });
+    assert.equal(mod.deletePreset('gif', 'missing'), false);
+    assert.equal(mod.loadPresets('gif').length, 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────── ID COLLISION ────────
+
+describe('SEAN-94 preset-storage — id collision = overwrite-in-place', () => {
+  it('saving with an existing id replaces that entry, not duplicates', () => {
+    mod.savePreset('gif', {
+      id: 'p1',
+      name: 'first label',
+      args: { fps: '10' },
+      createdAt: 1,
+    });
+    mod.savePreset('gif', {
+      id: 'p1',
+      name: 'updated label',
+      args: { fps: '24', width: '320' },
+      createdAt: 2,
+    });
+    const presets = mod.loadPresets('gif');
+    assert.equal(presets.length, 1);
+    assert.equal(presets[0]?.name, 'updated label');
+    assert.equal(presets[0]?.args.fps, '24');
+    assert.equal(presets[0]?.args.width, '320');
+  });
+});
+
+// ─────────────────────────────────────────────────────── DEFENSIVE PARSE ─────
+
+describe('SEAN-94 preset-storage — defensive parsing', () => {
+  it('returns [] when the stored JSON is malformed', () => {
+    installFakeStorage(); // re-install to grab the reference
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.rawSet('converter.presets.gif', 'not-json{{{');
+    assert.deepEqual(mod.loadPresets('gif'), []);
+  });
+
+  it('returns [] when the JSON parses but is not an array', () => {
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.rawSet(
+      'converter.presets.gif',
+      JSON.stringify({ id: 'oops' }),
+    );
+    assert.deepEqual(mod.loadPresets('gif'), []);
+  });
+
+  it('drops individual records whose shape is invalid, keeping the rest', () => {
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.rawSet(
+      'converter.presets.gif',
+      JSON.stringify([
+        { id: 'good', name: 'ok', args: { fps: '24' }, createdAt: 0 },
+        { id: 'bad-no-name', args: {}, createdAt: 0 },
+        { id: 'bad-args-not-object', name: 'x', args: 'oops', createdAt: 0 },
+        null,
+        'string-not-object',
+      ]),
+    );
+    const loaded = mod.loadPresets('gif');
+    assert.equal(loaded.length, 1);
+    assert.equal(loaded[0]?.id, 'good');
+  });
+
+  it('returns [] when localStorage.getItem throws (storage disabled)', () => {
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.throwOnRead = true;
+    assert.deepEqual(mod.loadPresets('gif'), []);
+  });
+});
+
+// ─────────────────────────────────────────────────────── QUOTA FALLBACK ──────
+
+describe('SEAN-94 preset-storage — quota fallback', () => {
+  it('returns false from savePreset when storage throws QuotaExceededError', () => {
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.quotaExceeded = true;
+    const ok = mod.savePreset('gif', {
+      id: 'p1',
+      name: 'too big',
+      args: {},
+      createdAt: 0,
+    });
+    assert.equal(ok, false);
+  });
+
+  it('does NOT throw — callers can ignore the return value safely', () => {
+    const win = (
+      globalThis as unknown as {
+        window: { localStorage: FakeStorage };
+      }
+    ).window;
+    win.localStorage.quotaExceeded = true;
+    assert.doesNotThrow(() => {
+      mod.savePreset('gif', { id: 'p', name: 'x', args: {}, createdAt: 0 });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────── EXPORT / IMPORT ─────
+
+describe('SEAN-94 preset-storage — export JSON', () => {
+  it('produces a versioned envelope with only non-empty operations', () => {
+    mod.savePreset('gif', {
+      id: 'g1',
+      name: 'Twitter gif',
+      args: { fps: '24', width: '320' },
+      createdAt: 1,
+    });
+    mod.savePreset('convert', {
+      id: 'c1',
+      name: 'Discord webm',
+      args: { crf: '28' },
+      createdAt: 2,
+    });
+    // Operations with no presets must NOT appear in the envelope.
+    const payload = mod.buildExportPayload(999);
+    assert.equal(payload.version, mod.SCHEMA_VERSION);
+    assert.equal(payload.exportedAt, 999);
+    assert.ok(payload.presetsByOperation.gif);
+    assert.ok(payload.presetsByOperation.convert);
+    assert.equal(payload.presetsByOperation.trim, undefined);
+    assert.equal(payload.presetsByOperation.gif?.length, 1);
+  });
+
+  it('exportPresetsAsJson is pretty-printed valid JSON', () => {
+    mod.savePreset('gif', {
+      id: 'g1',
+      name: 'a',
+      args: { fps: '10' },
+      createdAt: 1,
+    });
+    const json = mod.exportPresetsAsJson(0);
+    // Parses cleanly back into an export payload.
+    const reparsed = JSON.parse(json);
+    assert.ok(mod.isExportPayload(reparsed));
+    // Pretty-print produces newlines so a user can read the file.
+    assert.match(json, /\n/);
+  });
+});
+
+describe('SEAN-94 preset-storage — importPresets', () => {
+  it('merges a clean export payload into empty storage', () => {
+    const payload = {
+      version: mod.SCHEMA_VERSION,
+      exportedAt: 0,
+      presetsByOperation: {
+        gif: [
+          { id: 'g1', name: 'Twitter gif', args: { fps: '24' }, createdAt: 1 },
+        ],
+        convert: [
+          { id: 'c1', name: 'Discord webm', args: { crf: '28' }, createdAt: 2 },
+        ],
+      },
+    };
+    const result = mod.importPresets(JSON.stringify(payload));
+    assert.equal(result.ok, true);
+    assert.equal(result.addedByOperation?.gif, 1);
+    assert.equal(result.addedByOperation?.convert, 1);
+    assert.equal(mod.loadPresets('gif').length, 1);
+    assert.equal(mod.loadPresets('convert').length, 1);
+  });
+
+  it('overwrites existing presets with the same id (re-import is idempotent)', () => {
+    mod.savePreset('gif', {
+      id: 'g1',
+      name: 'old name',
+      args: { fps: '10' },
+      createdAt: 1,
+    });
+    const payload = {
+      version: mod.SCHEMA_VERSION,
+      exportedAt: 0,
+      presetsByOperation: {
+        gif: [
+          {
+            id: 'g1',
+            name: 'new name',
+            args: { fps: '24' },
+            createdAt: 2,
+          },
+        ],
+      },
+    };
+    const result = mod.importPresets(JSON.stringify(payload));
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.addedByOperation?.gif,
+      0,
+      'overwrite must count as 0 added',
+    );
+    const presets = mod.loadPresets('gif');
+    assert.equal(presets.length, 1);
+    assert.equal(presets[0]?.name, 'new name');
+    assert.equal(presets[0]?.args.fps, '24');
+  });
+
+  it('does NOT wipe other operations on partial import', () => {
+    mod.savePreset('convert', {
+      id: 'keep',
+      name: 'keep me',
+      args: { crf: '20' },
+      createdAt: 1,
+    });
+    const payload = {
+      version: mod.SCHEMA_VERSION,
+      exportedAt: 0,
+      presetsByOperation: {
+        gif: [{ id: 'g1', name: 'a', args: { fps: '10' }, createdAt: 1 }],
+      },
+    };
+    mod.importPresets(JSON.stringify(payload));
+    assert.equal(mod.loadPresets('convert').length, 1);
+    assert.equal(mod.loadPresets('convert')[0]?.id, 'keep');
+  });
+
+  it('rejects malformed JSON with reason: invalid-json', () => {
+    const result = mod.importPresets('not-json{{{');
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'invalid-json');
+  });
+
+  it('rejects payloads with the wrong shape with reason: invalid-shape', () => {
+    const result = mod.importPresets(JSON.stringify({ hello: 'world' }));
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'invalid-shape');
+  });
+
+  it('rejects future schema versions with reason: unsupported-version', () => {
+    const result = mod.importPresets(
+      JSON.stringify({
+        version: mod.SCHEMA_VERSION + 1,
+        exportedAt: 0,
+        presetsByOperation: {},
+      }),
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'unsupported-version');
+  });
+});
+
+// ─────────────────────────────────────────────────────── newPresetId ─────────
+
+describe('SEAN-94 preset-storage — newPresetId', () => {
+  it('produces a non-empty string', () => {
+    const id = mod.newPresetId();
+    assert.equal(typeof id, 'string');
+    assert.ok(id.length > 0);
+  });
+
+  it('produces unique ids across many calls', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i += 1) {
+      ids.add(mod.newPresetId());
+    }
+    assert.equal(ids.size, 100);
+  });
+});
+
+// ─────────────────────────────────────────────────────── clearAllPresets ─────
+
+describe('SEAN-94 preset-storage — clearAllPresets', () => {
+  it('removes every operation key', () => {
+    mod.savePreset('gif', { id: 'g', name: 'g', args: {}, createdAt: 0 });
+    mod.savePreset('convert', { id: 'c', name: 'c', args: {}, createdAt: 0 });
+    mod.clearAllPresets();
+    assert.deepEqual(mod.loadPresets('gif'), []);
+    assert.deepEqual(mod.loadPresets('convert'), []);
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/preset-storage.ts
+++ b/apps/ffmpeg-converter/web/src/components/preset-storage.ts
@@ -1,0 +1,410 @@
+// SEAN-94 — saved preset library backed by localStorage.
+//
+// STRATEGY.md §"Repeat-customer hooks" item #2: a user converts a 1080p MP4
+// to 720p WebM at CRF 28, hits "Save as 'Discord webm'", and on the next
+// visit the preset shows up as an extra chip in the converter panel. No
+// login, no account — just localStorage. JSON export/import for cross-device
+// sync.
+//
+// Combined with SEAN-93 URL-state, this is the loop that turns the one-shot
+// converter into a personal tool: discover preset → tweak → save → reach
+// for it next time. The saved preset shape is intentionally just the
+// URL-state map plus a name + id + timestamp — the URL-state whitelist is
+// the source of truth for "which params are real", so saved presets get the
+// same hostile-key protection for free.
+//
+// Storage layout
+// ──────────────
+// One key per operation: `converter.presets.gif`, `converter.presets.convert`,
+// etc. The gif page MUST NOT show a user's webm presets (they'd be
+// inapplicable on the GIF row), so per-operation isolation falls out of the
+// key shape rather than being a runtime filter.
+//
+// Each key holds a JSON-serialised `SavedPreset[]`. We keep the array (not
+// a map) so the chip rendering order matches save order, and so the export
+// JSON is human-readable without sorting.
+//
+// Quota fallback
+// ──────────────
+// localStorage can throw `QuotaExceededError` (Safari private mode caps
+// quota at ~0 bytes; some Firefox configurations do too). Every write goes
+// through `safeWrite` which swallows the error and returns `false`. Callers
+// that care surface this to the UI; callers that don't (autosave-style
+// writes) just silently degrade. Reads from a non-existent or malformed key
+// return `[]` so the rest of the app keeps working.
+//
+// SSR safety
+// ──────────
+// All localStorage access is gated behind a `typeof window === 'undefined'`
+// check so importing this module from a server component (or a non-browser
+// test runner) is a no-op rather than a crash.
+
+import type { Operation } from '@/ops/types';
+import type { UrlState } from './url-state';
+
+// ─────────────────────────────────────────────────────── TYPES ───────────────
+
+/**
+ * A single saved preset. The `args` map is exactly the URL-state shape — a
+ * map of whitelisted param names to string values — so saving a preset is
+ * "snapshot the current URL-state and tag it with a name and id".
+ *
+ * Shape kept stable across versions for the export JSON contract. If a
+ * future schema bump is needed we'll bump `SCHEMA_VERSION` and write a
+ * migration in `loadPresets`.
+ */
+export interface SavedPreset {
+  /** Stable id — used by the chip's delete button and as the React key. */
+  id: string;
+  /** User-supplied label that shows up on the chip. */
+  name: string;
+  /** URL-state args at save time. Same shape as `UrlState`. */
+  args: UrlState;
+  /** Unix ms timestamp of save. Surfaced in the export JSON for sorting. */
+  createdAt: number;
+}
+
+/**
+ * Schema version baked into the export JSON so future imports can refuse or
+ * migrate older payloads. Bump on any breaking change to `SavedPreset` or
+ * the storage layout.
+ */
+export const SCHEMA_VERSION = 1;
+
+/**
+ * The export JSON envelope — one blob per device, covering all operations.
+ * The user downloads this from "Export presets" and re-imports it on a
+ * second device.
+ */
+export interface ExportPayload {
+  version: number;
+  exportedAt: number;
+  /**
+   * Map of operation → preset list. Empty operations are omitted to keep
+   * the file small and human-readable.
+   */
+  presetsByOperation: Partial<Record<Operation, SavedPreset[]>>;
+}
+
+// ─────────────────────────────────────────────────────── KEYS ────────────────
+
+/** Key prefix shared across operations. Public so tests can clean up. */
+export const STORAGE_KEY_PREFIX = 'converter.presets.';
+
+/**
+ * Build the localStorage key for an operation. Pure — exported so tests can
+ * seed/clear a key without going through the read/write helpers.
+ */
+export function storageKeyFor(operation: Operation): string {
+  return `${STORAGE_KEY_PREFIX}${operation}`;
+}
+
+// ─────────────────────────────────────────────────────── INTERNAL I/O ────────
+
+/**
+ * Best-effort localStorage read. Returns `null` if `window` is undefined,
+ * the key is missing, or the access throws (some browsers throw on
+ * `localStorage.getItem` when storage is disabled, not just on writes).
+ */
+function safeRead(key: string): string | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort localStorage write. Returns `true` on success, `false` on
+ * quota exceeded / disabled storage / SSR. Callers that surface the failure
+ * to the UI check the return value; autosave-style callers ignore it.
+ */
+function safeWrite(key: string, value: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    window.localStorage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Best-effort localStorage delete. Returns `true` on success. SSR-safe.
+ */
+function safeRemove(key: string): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    window.localStorage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────── VALIDATION ──────────
+
+/**
+ * Type-guard a parsed JSON blob into `SavedPreset[]`. Defensive because
+ * localStorage is user-writable: a hostile or out-of-date payload should be
+ * dropped silently rather than crashing the chip render. Each entry is
+ * validated independently so one bad record doesn't poison the rest.
+ */
+export function isSavedPreset(value: unknown): value is SavedPreset {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== 'string' || v.id === '') return false;
+  if (typeof v.name !== 'string') return false;
+  if (typeof v.createdAt !== 'number') return false;
+  if (!v.args || typeof v.args !== 'object') return false;
+  // args must be a string→string map; any non-string value is suspicious.
+  for (const [k, val] of Object.entries(v.args as Record<string, unknown>)) {
+    if (typeof k !== 'string') return false;
+    if (typeof val !== 'string') return false;
+  }
+  return true;
+}
+
+// ─────────────────────────────────────────────────────── PUBLIC API ──────────
+
+/**
+ * Read every saved preset for `operation`. Returns `[]` when the key is
+ * missing, malformed, or storage is unavailable — never throws. Order is
+ * preserved (chip rendering order matches save order).
+ */
+export function loadPresets(operation: Operation): SavedPreset[] {
+  const raw = safeRead(storageKeyFor(operation));
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  return parsed.filter(isSavedPreset);
+}
+
+/**
+ * Persist `presets` as the full preset list for `operation`. Pure-overwrite,
+ * not append — callers who want to append must read, mutate, then call this.
+ * Returns `true` on success, `false` on quota / SSR. The write goes through
+ * `JSON.stringify` so any non-serialisable args (Functions, BigInts) blow
+ * up loudly here rather than silently producing garbage on the next read.
+ */
+export function writePresets(
+  operation: Operation,
+  presets: SavedPreset[],
+): boolean {
+  return safeWrite(storageKeyFor(operation), JSON.stringify(presets));
+}
+
+/**
+ * Append a new preset to `operation`'s list. Returns `true` on success,
+ * `false` on quota / SSR. The id collision case (extremely unlikely with
+ * `crypto.randomUUID`, but possible if the caller passes a hand-rolled id)
+ * is resolved by overwriting the existing entry — the alternative (reject)
+ * would surprise users who edited a preset and re-saved it under the same
+ * id.
+ */
+export function savePreset(operation: Operation, preset: SavedPreset): boolean {
+  const existing = loadPresets(operation);
+  const next = existing.filter((p) => p.id !== preset.id);
+  next.push(preset);
+  return writePresets(operation, next);
+}
+
+/**
+ * Remove the preset with `id` from `operation`'s list. Returns `true` on
+ * success, `false` on quota / SSR / preset-not-found. The not-found case is
+ * surfaced because callers (the chip's ✕ button) want to know whether the
+ * UI should re-render — though in practice an immediate `loadPresets` would
+ * pick up the same outcome.
+ */
+export function deletePreset(operation: Operation, id: string): boolean {
+  const existing = loadPresets(operation);
+  const next = existing.filter((p) => p.id !== id);
+  if (next.length === existing.length) return false;
+  return writePresets(operation, next);
+}
+
+/**
+ * Generate a stable id for a new preset. Uses `crypto.randomUUID` when
+ * available (every modern browser since ~2022, plus Node 19+) and falls
+ * back to a timestamp-plus-random string otherwise so the function never
+ * throws — the saved preset format only requires that ids be unique within
+ * one operation's list, not globally unique.
+ */
+export function newPresetId(): string {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID();
+  }
+  return `p_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+// ─────────────────────────────────────────────────────── EXPORT / IMPORT ─────
+
+/**
+ * List of every operation we know how to load presets for. Mirrors the
+ * `Operation` type union — kept as a runtime array because we need to
+ * iterate it for export. Adding a new operation requires updating this
+ * list (and `URL_PARAM_WHITELIST` in url-state.ts); a missing entry just
+ * means the export JSON won't include that op's presets.
+ */
+const ALL_OPERATIONS: readonly Operation[] = [
+  'convert',
+  'compress',
+  'extract-audio',
+  'extract-frames',
+  'trim',
+  'resize',
+  'rotate',
+  'gif',
+  'merge',
+  'mute',
+  'change-speed',
+  'add-subtitles',
+  'remove-audio',
+  'reverse',
+  'thumbnail',
+  'contact-sheet',
+  'normalize-audio',
+  'image-convert',
+];
+
+/**
+ * Build an `ExportPayload` covering every operation that has at least one
+ * saved preset. Empty operations are dropped so the file stays small and
+ * human-readable. The result is what the "Export presets" button serialises
+ * via `exportPresetsAsJson`.
+ */
+export function buildExportPayload(now: number = Date.now()): ExportPayload {
+  const presetsByOperation: Partial<Record<Operation, SavedPreset[]>> = {};
+  for (const op of ALL_OPERATIONS) {
+    const presets = loadPresets(op);
+    if (presets.length > 0) {
+      presetsByOperation[op] = presets;
+    }
+  }
+  return {
+    version: SCHEMA_VERSION,
+    exportedAt: now,
+    presetsByOperation,
+  };
+}
+
+/**
+ * JSON-stringify the export payload. Pretty-printed with 2-space indent so a
+ * user who opens the file in a text editor can read it without tooling.
+ */
+export function exportPresetsAsJson(now: number = Date.now()): string {
+  return JSON.stringify(buildExportPayload(now), null, 2);
+}
+
+/**
+ * Result of an import. `addedByOperation` counts new presets per operation
+ * (overwrites of an existing id count as 0, not 1, to match the "imported
+ * X new presets" UI message).
+ */
+export interface ImportResult {
+  ok: boolean;
+  reason?:
+    | 'invalid-json'
+    | 'invalid-shape'
+    | 'unsupported-version'
+    | 'quota-exceeded';
+  addedByOperation?: Partial<Record<Operation, number>>;
+}
+
+/**
+ * Validate an arbitrary parsed value as an `ExportPayload`. Returns the
+ * narrowed value or `null` if anything looks off. Used by `importPresets`
+ * to gate writes — never throws, never partially applies.
+ */
+export function isExportPayload(value: unknown): value is ExportPayload {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.version !== 'number') return false;
+  if (typeof v.exportedAt !== 'number') return false;
+  if (!v.presetsByOperation || typeof v.presetsByOperation !== 'object') {
+    return false;
+  }
+  // Validate each operation's preset list — we tolerate unknown operation
+  // keys (forwards-compat) but reject any list whose entries aren't
+  // SavedPreset-shaped.
+  for (const presets of Object.values(
+    v.presetsByOperation as Record<string, unknown>,
+  )) {
+    if (!Array.isArray(presets)) return false;
+    if (!presets.every(isSavedPreset)) return false;
+  }
+  return true;
+}
+
+/**
+ * Merge an import payload into the current localStorage. Existing presets
+ * with the same id are overwritten (so re-importing the same export is a
+ * no-op rather than a duplication). Operations are merged independently so
+ * importing a payload that only has gif presets doesn't wipe the user's
+ * convert presets.
+ *
+ * Returns an `ImportResult` describing what happened. The function never
+ * throws — malformed input returns `{ ok: false, reason: ... }` so the UI
+ * can surface a friendly message.
+ */
+export function importPresets(json: string): ImportResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: 'invalid-json' };
+  }
+  if (!isExportPayload(parsed)) {
+    return { ok: false, reason: 'invalid-shape' };
+  }
+  if (parsed.version > SCHEMA_VERSION) {
+    return { ok: false, reason: 'unsupported-version' };
+  }
+
+  const addedByOperation: Partial<Record<Operation, number>> = {};
+  for (const [op, incoming] of Object.entries(parsed.presetsByOperation)) {
+    if (!incoming || incoming.length === 0) continue;
+    const operation = op as Operation;
+    const existing = loadPresets(operation);
+    const existingIds = new Set(existing.map((p) => p.id));
+    const merged = [...existing];
+    let added = 0;
+    for (const preset of incoming) {
+      if (existingIds.has(preset.id)) {
+        // Overwrite the existing entry in place so render order stays stable.
+        const idx = merged.findIndex((p) => p.id === preset.id);
+        if (idx >= 0) merged[idx] = preset;
+      } else {
+        merged.push(preset);
+        added += 1;
+      }
+    }
+    const ok = writePresets(operation, merged);
+    if (!ok) {
+      return { ok: false, reason: 'quota-exceeded', addedByOperation };
+    }
+    addedByOperation[operation] = added;
+  }
+
+  return { ok: true, addedByOperation };
+}
+
+/**
+ * Wipe every preset key this module owns. Used by the test suite (and a
+ * future "Clear all saved presets" UI) to reset state without leaving stale
+ * keys behind.
+ */
+export function clearAllPresets(): void {
+  for (const op of ALL_OPERATIONS) {
+    safeRemove(storageKeyFor(op));
+  }
+}


### PR DESCRIPTION
Closes #94

## Summary

- New `preset-storage.ts` typed wrapper around localStorage. Per-operation keys (`converter.presets.gif`, `converter.presets.convert`, etc.) so the gif page never sees the user's webm presets. Quota fallback returns `false` instead of throwing on Safari-private-mode-style failures, defensive parsing drops malformed records without poisoning the rest, and the export/import format is a versioned envelope (`{ version, exportedAt, presetsByOperation }`) for cross-device sync.
- `ConverterPanel.tsx` grows a `<SavedPresetsBar />` chip row above the drop zone. Saved presets render as chips alongside the in-built ones; each chip applies via the existing URL-state path (clicking writes through `applyUrlState`, the panel's existing `useEffect` re-syncs `extraArgs` and the displayed ffmpeg command). Per-chip ✕ deletes; "+ Save as preset…" snapshots the current URL state under a user-supplied name; "JSON" toggles export-download / import-from-file controls.
- Saved preset shape is just `UrlState` + name + id + timestamp, so the URL-state whitelist stays the source of truth for "which params are real" — hostile keys can't slip in via a tampered export.

## Test plan

- [x] `yarn test:preset-storage` (28 new tests across 11 suites — key shape, round-trip, per-op isolation, defensive parsing, quota fallback, export/import).
- [x] `yarn test` (full suite still green: 4 + 9 + 6 + 8 + 5 + 13 + 9 + 12 + 21 + 28 = passing).
- [x] `tsc --noEmit` clean.
- [x] `yarn check` produces no new errors / warnings on touched files (pre-existing warnings in unrelated files remain).
- [ ] Manual smoke (asks Sean): on `/gif/mp4-to-gif?fps=24&width=320`, click "Save as preset…", name it "Twitter gif", reload — chip appears. Click chip on a different page (e.g. fresh `/gif/mp4-to-gif`), URL updates to `?fps=24&width=320` and the ffmpeg command shows `fps=24,scale=320:-1`.
- [ ] Manual smoke: export JSON, clear localStorage, import JSON — chip reappears.