### PR TITLE
[SEAN-92] feat: gif preset chips + custom controls

### DIFF
--- a/apps/ffmpeg-converter/docs/STRATEGY.md
+++ b/apps/ffmpeg-converter/docs/STRATEGY.md
@@ -294,3 +294,91 @@ get cancelled in the first second (suggests users were going somewhere else
 and the auto-fire is wasting their bandwidth + ours). At that point, flip to
 a 1-click confirm gate (single button per format, no separate Convert button)
 and re-measure.
+
+### SEAN-92 — gif preset chips + customise disclosure
+
+**Status:** locked, 2026-05-08.
+
+**Question:** GIF is the operation with the richest size/quality knob set —
+fps, width, dither, palette size, trim — and the one users tinker with most
+(Discord 8 MB ceilings, Bluesky 50 MB, Slack quirks). Until #92 every
+`/gif/[slug]` page hard-coded `fps=10, width=480, default dither, 256
+colours` with no user controls. Should the gif tool pages expose all of
+those knobs at once (CloudConvert-style 30-field dialog), none of them
+(status quo), or stage the disclosure?
+
+**Decision:** progressive disclosure with a three-chip preset row (Smooth /
+Compact / Tiny) shown immediately below the converter panel, plus an
+optional "Customize" `<details>` panel revealing fps chips
+(10/15/20/24/30), width chips (240/320/480/640), and start + duration trim
+sliders. The default chip is Smooth (480p, matching the post-#91 width
+default). Picking any chip — preset OR fps/width override — re-keys the
+inner `<ConverterPanel />`, which unmounts the old `<DropZone />` and fires
+its `AbortController` cleanup, cancelling the in-flight upload before
+mounting a fresh panel with the new args. Same SEAN-79/-81 abort pattern
+the homepage chip row uses.
+
+**Why this shape rather than the layer-cake from §"Progressive disclosure":**
+
+- The full 4-layer cake (drop → format → preset → advanced → command)
+  belongs to the homepage flow where the user hasn't picked an op yet.
+  Slug pages already locked the op and the output format via the URL —
+  the only remaining axes are the gif-specific knobs.
+- Three named presets cover the dominant Discord/Slack/Bluesky use cases
+  without forcing the user to read about palette quantisation. The
+  customise panel is for the second-use power user — it stays collapsed
+  by default.
+- `<details>` is a real HTML element, so it works without JS state and
+  composes cleanly with the rest of the server-rendered page. We could
+  promote it to a remembered preference in localStorage later (the
+  STRATEGY.md repeat-customer hooks list) without restructuring.
+
+**The live ffmpeg command preview** is the dev-funnel hook from STRATEGY
+§1 in concrete form: `renderGifFfmpegCommand(inputExt, effectivePreset)`
+re-runs on every state change and the new command is forwarded to
+`<ConverterPanel />`'s existing `ffmpegCommand` prop, which surfaces it on
+the result block with a copy button. Dev users can paste the exact command
+we just ran into their own terminal — same args, same filter graph.
+
+**Backend extension:** `gif_from_video` in `ops.go` reads `width`, `fps`,
+`dither`, `max_colors`, `start`, `duration` from the multipart form. All
+default to the legacy values (480, 10, sierra2_4a, 256, no trim) so callers
+that don't pass an override see the same output as before. Trim is wired as
+input-side `-ss` / `-t` (not as a filter), so the palettegen pass samples
+only the trimmed window — otherwise the GIF gets quantised against frames
+the user can't see.
+
+**Out of scope for v1:**
+
+- **Dither method UI** — sticks to default `sierra2_4a` for Smooth/Compact,
+  `none` for Tiny. The Tiny chip's hard-edge look is the point of the
+  preset (smaller files, no dithering noise on flat backgrounds).
+- **Max-colours UI** — sticks to 256. Dropping below 256 helps file size
+  on cartoonish content but tanks photo-derived clips. Add later if
+  Discord-size feedback shows demand.
+- **Reverse / boomerang** — separate op, separate pSEO page.
+- **Speed** — same; `change_speed` already has its own slug template.
+
+**Files:**
+
+- `apps/ffmpeg-converter/web/src/components/GifPresetPanel.tsx` — new
+  client wrapper around `<ConverterPanel />`, owns the chip + customise
+  state and re-renders the live ffmpeg command.
+- `apps/ffmpeg-converter/web/src/components/ToolPage.tsx` — branches on
+  `row.operation === 'gif'` to mount `<GifPresetPanel />` instead of the
+  plain `<ConverterPanel />`.
+- `apps/ffmpeg-converter/web/src/components/converter-row-args.ts` —
+  `buildExtraArgs` forwards the new `width`/`dither`/`maxColors`/
+  `trimStartSec`/`trimDurationSec` fields when present on the row preset.
+- `apps/ffmpeg-converter/web/src/ops/types.ts` — `OperationPreset`
+  extended with the new fields.
+- `apps/ffmpeg-converter/ops.go` — `gif_from_video` reads the six fields
+  from `extraArgs` with backward-compatible defaults.
+- `apps/ffmpeg-converter/e2e_test.go` — per-preset width + fps assertions
+  via ffprobe.
+
+**Re-revisit if:** advanced-panel open rate (the `<details>` element in
+GifPresetPanel) sits above 40 % across gif pages — at that point the panel
+has earned promotion to default-open + remembered-in-localStorage. Or if
+preset-chip metrics show one chip dominating: collapse to that as the
+single default and demote the others to the customise panel.

--- a/apps/ffmpeg-converter/e2e_test.go
+++ b/apps/ffmpeg-converter/e2e_test.go
@@ -1014,6 +1014,211 @@ func TestConvert_RealFfmpeg_GifFromVideo_WidthOverride(t *testing.T) {
 	}
 }
 
+// SEAN-92: each preset chip on `/gif/[slug]` (Smooth/Compact/Tiny) must
+// produce a GIF at its advertised width AND frame rate. The chip values come
+// straight from the AC; the test drives the (width, fps) tuple straight to
+// the backend `extraArgs` to lock the contract — if the chip values change
+// in the frontend, the test moves with them.
+func TestConvert_RealFfmpeg_GifFromVideo_Presets(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not on PATH")
+	}
+	ffprobePath, ffprobeErr := exec.LookPath("ffprobe")
+	if ffprobeErr != nil {
+		t.Skip("ffprobe not on PATH – needed to verify gif width + fps")
+	}
+
+	ts := newCoreServer(t)
+	tmpDir := t.TempDir()
+
+	// 2-second source so palettegen has at least 20 frames at 10 fps to
+	// sample — short enough that even Smooth (20 fps × 2 s = 40 frames at
+	// 480 px) finishes in well under the test timeout.
+	inputPath := tmpDir + "/input.mp4"
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "color=c=blue:s=1920x1080:r=30:d=2",
+		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "40",
+		"-pix_fmt", "yuv420p", inputPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not generate test video: %v\n%s", err, out)
+	}
+	inputData, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+
+	cases := []struct {
+		name      string
+		args      map[string]string
+		wantWidth int
+		wantFps   string // ffprobe returns frame rate as "20/1" etc.
+	}{
+		{
+			name:      "smooth",
+			args:      map[string]string{"width": "480", "fps": "20"},
+			wantWidth: 480,
+			wantFps:   "20/1",
+		},
+		{
+			name:      "compact",
+			args:      map[string]string{"width": "320", "fps": "15"},
+			wantWidth: 320,
+			wantFps:   "15/1",
+		},
+		{
+			name:      "tiny",
+			args:      map[string]string{"width": "240", "fps": "10", "dither": "none"},
+			wantWidth: 240,
+			wantFps:   "10/1",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			code, body := doConvert(t, ts, "gif_from_video",
+				map[string][]byte{"input.mp4": inputData}, tc.args, "")
+			if code != http.StatusOK {
+				t.Fatalf("want 200, got %d; body: %s", code, body)
+			}
+			var resp map[string]any
+			_ = json.Unmarshal(body, &resp)
+
+			dlResp, err := http.Get(ts.URL + resp["output"].(string))
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer dlResp.Body.Close()
+			gifBytes, _ := io.ReadAll(dlResp.Body)
+			gifPath := tmpDir + "/" + tc.name + ".gif"
+			if err := os.WriteFile(gifPath, gifBytes, 0o644); err != nil {
+				t.Fatalf("write gif: %v", err)
+			}
+
+			probe := exec.Command(ffprobePath,
+				"-v", "error", "-select_streams", "v:0",
+				"-show_entries", "stream=width,r_frame_rate",
+				"-of", "json", gifPath)
+			probeOut, err := probe.Output()
+			if err != nil {
+				t.Fatalf("ffprobe failed: %v", err)
+			}
+			var probed struct {
+				Streams []struct {
+					Width     int    `json:"width"`
+					FrameRate string `json:"r_frame_rate"`
+				} `json:"streams"`
+			}
+			if err := json.Unmarshal(probeOut, &probed); err != nil {
+				t.Fatalf("parse ffprobe: %v", err)
+			}
+			if len(probed.Streams) == 0 {
+				t.Fatalf("ffprobe found no video stream in %s gif", tc.name)
+			}
+			s := probed.Streams[0]
+			if s.Width != tc.wantWidth {
+				t.Errorf("%s preset: want width=%d, got %d", tc.name, tc.wantWidth, s.Width)
+			}
+			if s.FrameRate != tc.wantFps {
+				t.Errorf("%s preset: want r_frame_rate=%s, got %q", tc.name, tc.wantFps, s.FrameRate)
+			}
+		})
+	}
+}
+
+// SEAN-92: trim args (`start`, `duration`) must clip the output GIF to the
+// requested window. Locks in input-side -ss/-t semantics — if the backend
+// regresses to using filter-side trim, palettegen samples frames the user
+// can't see and the test still catches the duration regression here.
+func TestConvert_RealFfmpeg_GifFromVideo_Trim(t *testing.T) {
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not on PATH")
+	}
+	ffprobePath, ffprobeErr := exec.LookPath("ffprobe")
+	if ffprobeErr != nil {
+		t.Skip("ffprobe not on PATH – needed to verify gif duration")
+	}
+
+	ts := newCoreServer(t)
+	tmpDir := t.TempDir()
+
+	// 4-second source so a 1-second trim leaves an obvious window.
+	inputPath := tmpDir + "/input.mp4"
+	cmd := exec.Command("ffmpeg",
+		"-hide_banner", "-loglevel", "error", "-y",
+		"-f", "lavfi", "-i", "color=c=red:s=320x180:r=10:d=4",
+		"-c:v", "libx264", "-preset", "ultrafast", "-crf", "40",
+		"-pix_fmt", "yuv420p", inputPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("could not generate test video: %v\n%s", err, out)
+	}
+	inputData, err := os.ReadFile(inputPath)
+	if err != nil {
+		t.Fatalf("read input: %v", err)
+	}
+
+	code, body := doConvert(t, ts, "gif_from_video",
+		map[string][]byte{"input.mp4": inputData},
+		map[string]string{"width": "240", "fps": "10", "start": "1", "duration": "1"}, "")
+	if code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body: %s", code, body)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(body, &resp)
+
+	dlResp, err := http.Get(ts.URL + resp["output"].(string))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dlResp.Body.Close()
+	gifBytes, _ := io.ReadAll(dlResp.Body)
+	gifPath := tmpDir + "/trimmed.gif"
+	if err := os.WriteFile(gifPath, gifBytes, 0o644); err != nil {
+		t.Fatalf("write gif: %v", err)
+	}
+
+	probe := exec.Command(ffprobePath,
+		"-v", "error", "-select_streams", "v:0",
+		"-show_entries", "stream=duration,nb_read_frames",
+		"-count_frames",
+		"-of", "json", gifPath)
+	probeOut, err := probe.Output()
+	if err != nil {
+		t.Fatalf("ffprobe failed: %v", err)
+	}
+	var probed struct {
+		Streams []struct {
+			Duration     string `json:"duration"`
+			NbReadFrames string `json:"nb_read_frames"`
+		} `json:"streams"`
+	}
+	if err := json.Unmarshal(probeOut, &probed); err != nil {
+		t.Fatalf("parse ffprobe: %v", err)
+	}
+	if len(probed.Streams) == 0 {
+		t.Fatalf("ffprobe found no video stream in trimmed gif")
+	}
+	// At fps=10 for 1 s we expect ~10 frames. Allow a small tolerance for
+	// keyframe alignment on the -ss side.
+	frames := probed.Streams[0].NbReadFrames
+	if frames == "" {
+		t.Fatalf("ffprobe returned empty nb_read_frames: %s", probeOut)
+	}
+	// Parse manually to avoid pulling in another dep. Frame count should
+	// land in [8, 12] for a 1-second 10 fps trim.
+	var frameCount int
+	for _, c := range frames {
+		if c < '0' || c > '9' {
+			t.Fatalf("non-numeric nb_read_frames: %q", frames)
+		}
+		frameCount = frameCount*10 + int(c-'0')
+	}
+	if frameCount < 8 || frameCount > 12 {
+		t.Errorf("trim regression: want ~10 frames for 1s @ 10fps, got %d (full input would be 40)", frameCount)
+	}
+}
+
 // ── /billing/me (billing disabled) ───────────────────────────────────────────
 
 func TestBillingMe_BillingDisabled(t *testing.T) {

--- a/apps/ffmpeg-converter/ops.go
+++ b/apps/ffmpeg-converter/ops.go
@@ -609,11 +609,33 @@ func RegisterOps() map[string]*Operation {
 		Description: "Animated GIF from a video (palettegen for quality)",
 		DefaultExt:  ".gif",
 		Run: func(ctx context.Context, oc OpContext) error {
+			// SEAN-92: every knob now flows through extraArgs. Defaults match
+			// the legacy 480-wide / fps=10 / sierra2_4a / 256-colour behaviour
+			// so callers that don't pass a preset get the same output as before.
 			width := arg(oc, "width", "480")
+			fps := arg(oc, "fps", "10")
+			dither := arg(oc, "dither", "sierra2_4a")
+			maxColors := arg(oc, "max_colors", "256")
+			start := arg(oc, "start", "")
+			duration := arg(oc, "duration", "")
+
 			vf := fmt.Sprintf(
-				"fps=10,scale=%s:-1:flags=lanczos,split[a][b];[a]palettegen[p];[b][p]paletteuse",
-				width)
-			return ffmpegRun(ctx, "-i", oc.Inputs[0], "-vf", vf, oc.Output)
+				"fps=%s,scale=%s:-1:flags=lanczos,split[a][b];[a]palettegen=max_colors=%s[p];[b][p]paletteuse=dither=%s",
+				fps, width, maxColors, dither)
+
+			// Trim is implemented as input-side -ss / -t, not as a filter, so
+			// the palette is built from the trimmed window only — otherwise
+			// palettegen samples frames you can't see.
+			args := []string{}
+			if start != "" {
+				args = append(args, "-ss", start)
+			}
+			args = append(args, "-i", oc.Inputs[0])
+			if duration != "" {
+				args = append(args, "-t", duration)
+			}
+			args = append(args, "-vf", vf, oc.Output)
+			return ffmpegRun(ctx, args...)
 		},
 	})
 	add(&Operation{

--- a/apps/ffmpeg-converter/web/src/app/gif/[slug]/page.tsx
+++ b/apps/ffmpeg-converter/web/src/app/gif/[slug]/page.tsx
@@ -4,6 +4,12 @@
 // All rendering goes through the shared <ToolPage row={...} /> component —
 // no per-operation customisation lives here.
 //
+// SEAN-92: <ToolPage /> branches on `row.operation === 'gif'` and mounts
+// <GifPresetPanel /> instead of the plain <ConverterPanel />, which renders
+// the preset chip row + customise disclosure below the panel. Keeps this
+// route file purely declarative (slug → row → ToolPage) — the gif-specific
+// UI lives in the shared component, not the route.
+//
 // See `/convert/[slug]/page.tsx` for the full Phase 2 routing rationale.
 
 import type { Metadata } from 'next';

--- a/apps/ffmpeg-converter/web/src/components/GifPresetPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/GifPresetPanel.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+// SEAN-92 — GIF preset chips + customise disclosure.
+//
+// Wraps `<ConverterPanel />` for `/gif/[slug]` pages with the gif-specific
+// preset chip row + optional advanced controls. Keeps the slug page itself a
+// server component — only this wrapper opts into client state.
+//
+// Pattern matches `<HeroDrop />`'s SEAN-79/-81 chip row: changing the active
+// preset re-keys the inner `<ConverterPanel />`, which unmounts the old panel
+// (cancelling the in-flight request via `<DropZone />`'s AbortController
+// cleanup) and mounts a fresh one with the new args. The user gets a single
+// click to swap presets mid-conversion — no manual cancel + redrop.
+//
+// Out of scope for v1 (per ticket #92): dither method UI (sticks to default
+// `sierra2_4a` from the Tiny preset's `none`), max-colours UI (sticks to 256),
+// reverse/boomerang, speed.
+
+import { useMemo, useState } from 'react';
+import type { OperationPreset } from '@/ops/types';
+import { ConverterPanel, type ConverterPanelProps } from './ConverterPanel';
+
+// ─────────────────────────────────────────────── PRESETS ─────────────────────
+
+/**
+ * SEAN-92 — preset chip definitions. The labels and values come straight from
+ * the ticket's AC. `Tiny` uses `dither=none` per the AC's "no dither" hint;
+ * `Smooth`/`Compact` keep the default Floyd-Steinberg-equivalent (sierra2_4a)
+ * which the backend treats as default when the field is absent.
+ */
+export interface GifPresetChip {
+  /** Stable id used as the React key + URL-safe slug if we ever surface in URL state. */
+  id: 'smooth' | 'compact' | 'tiny';
+  /** Chip label shown to the user. */
+  label: string;
+  /** Preset values forwarded to the backend via `extraArgs`. */
+  preset: OperationPreset;
+}
+
+const smoothChip: GifPresetChip = {
+  id: 'smooth',
+  label: 'Smooth (480p, 20fps)',
+  preset: { width: 480, fps: 20 },
+};
+
+export const GIF_PRESET_CHIPS: GifPresetChip[] = [
+  smoothChip,
+  {
+    id: 'compact',
+    label: 'Compact (320p, 15fps)',
+    preset: { width: 320, fps: 15 },
+  },
+  {
+    id: 'tiny',
+    label: 'Tiny (240p, 10fps, no dither)',
+    preset: { width: 240, fps: 10, dither: 'none' },
+  },
+];
+
+const FPS_OPTIONS = [10, 15, 20, 24, 30] as const;
+const WIDTH_OPTIONS = [240, 320, 480, 640] as const;
+
+// ─────────────────────────────────────────────── ARG MAPPING ─────────────────
+
+/**
+ * Build the `extraArgs` map sent to the backend `gif_from_video` op. Mirrors
+ * the field-naming in `converter-row-args.ts::buildExtraArgs` — kept inline
+ * here because the values are derived from local component state, not the
+ * matrix row's static preset.
+ *
+ * Empty/zero trim values are dropped so the backend's "no -ss / no -t" path
+ * runs (palette is built from the full input).
+ */
+function buildPresetExtraArgs(preset: OperationPreset): Record<string, string> {
+  const args: Record<string, string> = {};
+  if (preset.width !== undefined) args.width = String(preset.width);
+  if (preset.fps !== undefined) args.fps = String(preset.fps);
+  if (preset.dither !== undefined) args.dither = preset.dither;
+  if (preset.maxColors !== undefined)
+    args.max_colors = String(preset.maxColors);
+  if (preset.trimStartSec !== undefined && preset.trimStartSec > 0) {
+    args.start = String(preset.trimStartSec);
+  }
+  if (preset.trimDurationSec !== undefined && preset.trimDurationSec > 0) {
+    args.duration = String(preset.trimDurationSec);
+  }
+  return args;
+}
+
+/**
+ * Re-render the ffmpeg command line shown to the dev-funnel user. Mirrors the
+ * shape of the command in the matrix (`ffmpeg -i input.X -vf '...' output.gif`)
+ * but with the live preset values substituted so the user can paste it into
+ * their own terminal with the exact same args we just used.
+ */
+export function renderGifFfmpegCommand(
+  inputExt: string,
+  preset: OperationPreset,
+): string {
+  const width = preset.width ?? 480;
+  const fps = preset.fps ?? 10;
+  const dither = preset.dither ?? 'sierra2_4a';
+  const maxColors = preset.maxColors ?? 256;
+  const filter =
+    `fps=${fps},scale=${width}:-1:flags=lanczos,split[a][b];` +
+    `[a]palettegen=max_colors=${maxColors}[p];` +
+    `[b][p]paletteuse=dither=${dither}`;
+  const trimFlags: string[] = [];
+  if (preset.trimStartSec !== undefined && preset.trimStartSec > 0) {
+    trimFlags.push(`-ss ${preset.trimStartSec}`);
+  }
+  // -t goes after -i in the actual command we run, but ffmpeg accepts both
+  // orderings; we surface the canonical shape for readability.
+  if (preset.trimDurationSec !== undefined && preset.trimDurationSec > 0) {
+    trimFlags.push(`-t ${preset.trimDurationSec}`);
+  }
+  const trim = trimFlags.length > 0 ? `${trimFlags.join(' ')} ` : '';
+  return `ffmpeg ${trim}-i input.${inputExt} -vf '${filter}' output.gif`;
+}
+
+// ─────────────────────────────────────────────── COMPONENT ───────────────────
+
+export interface GifPresetPanelProps
+  extends Omit<ConverterPanelProps, 'extraArgs' | 'ffmpegCommand'> {
+  /** Input format extension (no leading dot). Used to render the live ffmpeg
+   *  command preview. Examples: `mp4`, `mov`, `webm`. */
+  inputExt: string;
+  /**
+   * Initial preset id — defaults to `smooth` which matches the current
+   * 480-wide default behaviour after #91. Chosen because it preserves the
+   * width users get today; the fps bump from 10 to 20 is the Smooth chip's
+   * deliberate trade-off (richer motion, larger file).
+   */
+  initialPresetId?: GifPresetChip['id'];
+}
+
+export function GifPresetPanel({
+  inputExt,
+  initialPresetId = 'smooth',
+  ...converterProps
+}: GifPresetPanelProps) {
+  const [activePresetId, setActivePresetId] =
+    useState<GifPresetChip['id']>(initialPresetId);
+  const [customizeOpen, setCustomizeOpen] = useState(false);
+
+  // Custom overrides — when the user opens the panel and changes a value,
+  // it overrides the chip-preset's value. Reset on chip change so picking a
+  // chip is always a clean re-fire with the chip's exact values.
+  const [customFps, setCustomFps] = useState<number | null>(null);
+  const [customWidth, setCustomWidth] = useState<number | null>(null);
+  const [trimStart, setTrimStart] = useState<number>(0);
+  const [trimDuration, setTrimDuration] = useState<number>(0);
+
+  const baseChip = useMemo(
+    () =>
+      GIF_PRESET_CHIPS.find((c) => c.id === activePresetId) ??
+      // GIF_PRESET_CHIPS is a const array with three entries — index 0 is
+      // always defined. The `?? smoothChip` form keeps biome happy without
+      // resorting to a non-null assertion.
+      smoothChip,
+    [activePresetId],
+  );
+
+  // Effective preset = base chip + custom overrides + trim. The trim values
+  // are always live from the sliders (they live above the chip selection
+  // conceptually — clipping a section is a different intent from "smaller
+  // file or smoother motion").
+  const effectivePreset: OperationPreset = useMemo(
+    () => ({
+      ...baseChip.preset,
+      ...(customFps !== null ? { fps: customFps } : {}),
+      ...(customWidth !== null ? { width: customWidth } : {}),
+      ...(trimStart > 0 ? { trimStartSec: trimStart } : {}),
+      ...(trimDuration > 0 ? { trimDurationSec: trimDuration } : {}),
+    }),
+    [baseChip, customFps, customWidth, trimStart, trimDuration],
+  );
+
+  const extraArgs = useMemo(
+    () => buildPresetExtraArgs(effectivePreset),
+    [effectivePreset],
+  );
+
+  const ffmpegCommand = useMemo(
+    () => renderGifFfmpegCommand(inputExt, effectivePreset),
+    [inputExt, effectivePreset],
+  );
+
+  // Stable key forces ConverterPanel to remount whenever any arg changes.
+  // The remount unmounts the old DropZone, which fires its AbortController
+  // cleanup and cancels the in-flight upload — same pattern as HeroDrop.
+  // We hash the extraArgs into a single string so the key changes iff a
+  // value the backend cares about changed.
+  const panelKey = useMemo(
+    () =>
+      Object.entries(extraArgs)
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([k, v]) => `${k}=${v}`)
+        .join('&'),
+    [extraArgs],
+  );
+
+  // Picking a chip resets the custom overrides — clicking "Compact" should
+  // give exactly the Compact preset, not Compact-with-the-fps-you-tweaked.
+  const handleChipClick = (id: GifPresetChip['id']) => {
+    setActivePresetId(id);
+    setCustomFps(null);
+    setCustomWidth(null);
+  };
+
+  return (
+    <div className="w-full">
+      <ConverterPanel
+        key={panelKey}
+        {...converterProps}
+        extraArgs={extraArgs}
+        ffmpegCommand={ffmpegCommand}
+      />
+
+      {/* SEAN-92 — preset chip row. Lives below the converter panel per the
+          ticket AC: the chips are an after-the-drop affordance for tinkering,
+          not a pre-flight gate. Re-keying the panel above on any chip change
+          aborts the in-flight upload. */}
+      <div
+        className={[
+          'mt-6 flex flex-col gap-3',
+          'rounded-2xl border border-gray-800 bg-gray-900/40',
+          'px-4 py-4',
+        ].join(' ')}
+      >
+        <ul
+          aria-label="GIF preset"
+          className="flex flex-wrap items-center gap-2"
+        >
+          <li className="text-xs text-gray-500 uppercase tracking-wider">
+            Preset:
+          </li>
+          {GIF_PRESET_CHIPS.map((chip) => {
+            const active = chip.id === activePresetId;
+            return (
+              <li key={chip.id}>
+                <button
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => handleChipClick(chip.id)}
+                  className={[
+                    'inline-flex items-center rounded-full',
+                    'border px-3 py-1 text-xs font-medium transition-colors',
+                    active
+                      ? 'border-indigo-400 bg-indigo-500/20 text-white'
+                      : 'border-gray-700 bg-gray-900/60 text-gray-200 hover:border-indigo-500 hover:bg-indigo-500/10',
+                  ].join(' ')}
+                >
+                  {chip.label}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        <details
+          open={customizeOpen}
+          onToggle={(e) =>
+            setCustomizeOpen((e.target as HTMLDetailsElement).open)
+          }
+          className="text-sm"
+        >
+          <summary className="cursor-pointer select-none text-gray-300 hover:text-gray-100">
+            Customize
+          </summary>
+          <div className="mt-4 flex flex-col gap-4">
+            {/* fps row */}
+            <div>
+              <div className="mb-2 text-xs text-gray-500 uppercase tracking-wider">
+                FPS
+              </div>
+              <ul className="flex flex-wrap gap-2">
+                {FPS_OPTIONS.map((value) => {
+                  const active =
+                    (customFps ?? baseChip.preset.fps ?? 10) === value;
+                  return (
+                    <li key={value}>
+                      <button
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() => setCustomFps(value)}
+                        className={[
+                          'inline-flex items-center rounded-full',
+                          'border px-3 py-1 text-xs font-medium transition-colors',
+                          active
+                            ? 'border-indigo-400 bg-indigo-500/20 text-white'
+                            : 'border-gray-700 bg-gray-900/60 text-gray-200 hover:border-indigo-500 hover:bg-indigo-500/10',
+                        ].join(' ')}
+                      >
+                        {value}
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            {/* width row */}
+            <div>
+              <div className="mb-2 text-xs text-gray-500 uppercase tracking-wider">
+                Width
+              </div>
+              <ul className="flex flex-wrap gap-2">
+                {WIDTH_OPTIONS.map((value) => {
+                  const active =
+                    (customWidth ?? baseChip.preset.width ?? 480) === value;
+                  return (
+                    <li key={value}>
+                      <button
+                        type="button"
+                        aria-pressed={active}
+                        onClick={() => setCustomWidth(value)}
+                        className={[
+                          'inline-flex items-center rounded-full',
+                          'border px-3 py-1 text-xs font-medium transition-colors',
+                          active
+                            ? 'border-indigo-400 bg-indigo-500/20 text-white'
+                            : 'border-gray-700 bg-gray-900/60 text-gray-200 hover:border-indigo-500 hover:bg-indigo-500/10',
+                        ].join(' ')}
+                      >
+                        {value}px
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            {/* trim row */}
+            <div>
+              <div className="mb-2 text-xs text-gray-500 uppercase tracking-wider">
+                Trim
+              </div>
+              <div className="flex flex-col gap-3">
+                <label className="flex flex-col gap-1 text-xs text-gray-400">
+                  <span>
+                    Start: <span className="text-gray-200">{trimStart}s</span>
+                  </span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={60}
+                    step={0.5}
+                    value={trimStart}
+                    onChange={(e) => setTrimStart(Number(e.target.value))}
+                    className="w-full accent-indigo-400"
+                  />
+                </label>
+                <label className="flex flex-col gap-1 text-xs text-gray-400">
+                  <span>
+                    Duration:{' '}
+                    <span className="text-gray-200">
+                      {trimDuration === 0 ? 'full' : `${trimDuration}s`}
+                    </span>
+                  </span>
+                  <input
+                    type="range"
+                    min={0}
+                    max={30}
+                    step={0.5}
+                    value={trimDuration}
+                    onChange={(e) => setTrimDuration(Number(e.target.value))}
+                    className="w-full accent-indigo-400"
+                  />
+                </label>
+              </div>
+            </div>
+          </div>
+        </details>
+      </div>
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -35,6 +35,7 @@ import {
   resolveSiblings,
 } from './converter-row-args';
 import { FAQ } from './FAQ';
+import { GifPresetPanel } from './GifPresetPanel';
 import { JsonLd } from './JsonLd';
 
 export interface ToolPageProps {
@@ -84,19 +85,36 @@ export function ToolPage({ row, page }: ToolPageProps) {
         </p>
       </header>
 
-      {/* Convert panel — client-only state lives behind this boundary */}
+      {/* Convert panel — client-only state lives behind this boundary.
+          SEAN-92: gif rows render the preset-chip wrapper instead of the
+          plain ConverterPanel — the wrapper renders the chip row + customise
+          disclosure below the panel and re-keys ConverterPanel on every
+          arg change so chip clicks abort the in-flight upload and re-fire. */}
       <section className="mb-10" aria-label="Convert your file">
-        <ConverterPanel
-          goOp={row.goOp}
-          outputExt={formatToExt(row.outputFormat)}
-          accept={accept}
-          acceptLabel={acceptLabel}
-          extraArgs={extraArgs}
-          ffmpegCommand={row.ffmpegCommand}
-          reverseSlug={reverse?.slug}
-          reverseLabel={reverse?.label}
-          reverseOperation={reverse?.operation}
-        />
+        {row.operation === 'gif' ? (
+          <GifPresetPanel
+            inputExt={formatToExt(row.inputFormats[0] ?? row.outputFormat)}
+            goOp={row.goOp}
+            outputExt={formatToExt(row.outputFormat)}
+            accept={accept}
+            acceptLabel={acceptLabel}
+            reverseSlug={reverse?.slug}
+            reverseLabel={reverse?.label}
+            reverseOperation={reverse?.operation}
+          />
+        ) : (
+          <ConverterPanel
+            goOp={row.goOp}
+            outputExt={formatToExt(row.outputFormat)}
+            accept={accept}
+            acceptLabel={acceptLabel}
+            extraArgs={extraArgs}
+            ffmpegCommand={row.ffmpegCommand}
+            reverseSlug={reverse?.slug}
+            reverseLabel={reverse?.label}
+            reverseOperation={reverse?.operation}
+          />
+        )}
       </section>
 
       {/* SEAN-60 — "When to use this" paragraph. Renders directly under the

--- a/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
+++ b/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
@@ -71,6 +71,16 @@ export function buildExtraArgs(
   if (p.resolution !== undefined) args.resolution = p.resolution;
   if (p.fps !== undefined) args.fps = String(p.fps);
   if (p.audioBitrate !== undefined) args.audio_bitrate = p.audioBitrate;
+  // SEAN-92: gif preset chips + customise panel forward width/dither/max_colors
+  // and a start/duration trim. The Go op (`gif_from_video`) reads these from
+  // the multipart form; absent fields fall through to backend defaults.
+  if (p.width !== undefined) args.width = String(p.width);
+  if (p.dither !== undefined) args.dither = p.dither;
+  if (p.maxColors !== undefined) args.max_colors = String(p.maxColors);
+  if (p.trimStartSec !== undefined) args.start = String(p.trimStartSec);
+  if (p.trimDurationSec !== undefined) {
+    args.duration = String(p.trimDurationSec);
+  }
   return Object.keys(args).length > 0 ? args : undefined;
 }
 

--- a/apps/ffmpeg-converter/web/src/ops/types.ts
+++ b/apps/ffmpeg-converter/web/src/ops/types.ts
@@ -250,6 +250,41 @@ export interface OperationPreset {
   fps?: number;
   /** Audio bitrate (`64k`, `128k`, `192k`). */
   audioBitrate?: string;
+  /**
+   * SEAN-92: target output width in pixels. Used by gif/preview ops where
+   * the `scale` filter trades file size for fidelity. The matching filter
+   * keeps height auto-derived to preserve aspect (`scale=W:-1`).
+   */
+  width?: number;
+  /**
+   * SEAN-92: dither algorithm passed to ffmpeg's `paletteuse=dither=...`.
+   * Used by gif ops. Common values: `sierra2_4a` (default, balanced),
+   * `floyd_steinberg`, `bayer`, `none`.
+   */
+  dither?:
+    | 'sierra2_4a'
+    | 'floyd_steinberg'
+    | 'bayer'
+    | 'none'
+    | 'heckbert'
+    | 'sierra2'
+    | 'sierra3';
+  /**
+   * SEAN-92: max palette size for ffmpeg's `palettegen=max_colors=...`.
+   * GIF caps at 256; smaller values shrink the file at the cost of
+   * banding on gradients.
+   */
+  maxColors?: number;
+  /**
+   * SEAN-92: trim start offset in seconds. Forwarded as `start` to gif ops
+   * so users can clip a tighter window than the full input.
+   */
+  trimStartSec?: number;
+  /**
+   * SEAN-92: trim duration in seconds. Forwarded as `duration` to gif ops.
+   * Absent = use full remaining input.
+   */
+  trimDurationSec?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #92

## Summary

- New `<GifPresetPanel />` client wrapper around `<ConverterPanel />`. Renders below the drop zone on `/gif/[slug]` with three preset chips (Smooth 480p/20fps, Compact 320p/15fps, Tiny 240p/10fps no dither), a Customize `<details>` disclosure with fps + width chip rows, and start/duration trim sliders. Picking any chip or override re-keys the panel — the unmount fires `<DropZone />`'s `AbortController` cleanup so the in-flight upload is cancelled before the new one fires (same pattern as SEAN-79/-81's homepage chip row).
- Backend `gif_from_video` in `ops.go` now reads `width`, `fps`, `dither`, `max_colors`, `start`, `duration` from extraArgs. Defaults match the legacy 480/10/sierra2_4a/256/no-trim behaviour so existing callers see no change. Trim is wired as input-side `-ss` / `-t` so palettegen samples only the trimmed window.
- `OperationPreset` extended with `width` / `dither` / `maxColors` / `trimStartSec` / `trimDurationSec`. `buildExtraArgs` forwards them. ffmpeg command preview re-renders live from `renderGifFfmpegCommand(inputExt, effectivePreset)` and is forwarded into ConverterPanel's existing `ffmpegCommand` prop, which surfaces it on the result block (the dev-funnel hook from STRATEGY.md §1).
- Decision record appended to `apps/ffmpeg-converter/docs/STRATEGY.md` with the locked v1 scope (presets + customise + live command) and the explicit out-of-scopes (dither UI, max-colours UI, reverse, speed).

## Test plan

- [x] `go test ./apps/ffmpeg-converter/...` passes — new `TestConvert_RealFfmpeg_GifFromVideo_Presets` (smooth/compact/tiny subcases, ffprobe-verified width + r_frame_rate) and `TestConvert_RealFfmpeg_GifFromVideo_Trim` (frame-count window verification) lock the per-preset contract.
- [x] `tsc --noEmit` clean across the web app.
- [x] `next build` clean — `/gif/[slug]` static params still generate cleanly.
- [ ] Manual: drop a video on `/gif/mp4-to-gif`, click each preset chip, watch the upload abort + re-fire; verify the displayed ffmpeg command updates immediately as fps/width/trim change.
- [ ] Manual: open Customize, drag the trim sliders, confirm the result GIF only covers the picked window.