### PR TITLE
[SEAN-95] feat: advanced disclosure panel for video convert

### DIFF
--- a/apps/ffmpeg-converter/docs/STRATEGY.md
+++ b/apps/ffmpeg-converter/docs/STRATEGY.md
@@ -382,3 +382,87 @@ GifPresetPanel) sits above 40 % across gif pages — at that point the panel
 has earned promotion to default-open + remembered-in-localStorage. Or if
 preset-chip metrics show one chip dominating: collapse to that as the
 single default and demote the others to the customise panel.
+
+### SEAN-95 — Advanced disclosure control set
+
+**Status:** locked, 2026-05-08.
+
+**Question:** which knobs ship in the Layer-3 Advanced disclosure on
+`/convert/[slug]` video pages, and which stay behind the "Show everything"
+power-user toggle?
+
+**Decision:** the disclosure renders six controls in this order:
+
+1. **CRF slider** (0–51, default 23) — the canonical libx264/libx265/VP9
+   quality knob. Disabled when bitrate is set; the label flips to "Quality
+   (CRF) — overridden by bitrate" so the user understands why the slider
+   greyed out.
+2. **Video bitrate** text input (e.g. `2M`, `500k`) — overrides CRF when set.
+   Wins over CRF on the backend; the displayed ffmpeg command drops the
+   `-crf` flag and inserts `-b:v X` so copy-paste reflects the actual encode.
+3. **Encoder preset** dropdown (`ultrafast` … `veryslow`).
+4. **FPS** text input — leave blank for source rate.
+5. **Audio bitrate** text input.
+6. **Show everything** checkbox (Layer-3+ toggle, persisted in localStorage)
+   — when on, reveals a 7th control:
+7. **Video codec** dropdown (`libx264` / `libx265` / `libvpx-vp9` /
+   `libaom-av1` / `mpeg4`, default = format-appropriate auto). Hidden by
+   default because the format → codec mapping is correct 95 % of the time
+   and exposing a wrong-codec footgun (e.g. `libvpx-vp9` into an `.mp4`
+   container) on the casual flow burns the user.
+
+**Persistence:** disclosure expanded-state is stored in `localStorage` under
+`ffmpegConverter:advancedPanelExpanded`. Power users get the panel pre-
+expanded on subsequent visits. The "Show everything" toggle uses
+`ffmpegConverter:advancedPanelShowAll`. URL state per #93 carries the actual
+control values — share-links round-trip cleanly. Default values stay out of
+the URL so the URL stays minimal until the user customises something.
+
+**Why these six (not eight, not three):** the strategy doc's Layer-3 sketch
+calls out video codec, CRF, bitrate, fps, audio bitrate, sample rate,
+channels, plus the filters block. Sample rate and channels are out — they're
+audio-mastering decisions the wrong audience for a "convert MOV to MP4"
+visit. The filters block (resize/crop/trim/rotate/flip/speed/normalize) is
+out — those each have their own slug pages already (`/resize`, `/trim`,
+etc.), and stuffing them into a per-format Advanced panel duplicates the
+decision tree. Codec gets the power-user toggle because the format-appropriate
+default is correct for the load-bearing slug (mov-to-mp4 should not let a
+user pick libvpx-vp9 in one tap).
+
+**Out of scope (per ticket Notes):** pix_fmt, profile/level, two-pass
+encoding, lookahead, GOP. These are deeper-than-Layer-3 flags and belong
+either behind "Show everything" if/when we add them or in a future Layer-4
+"raw ffmpeg flags" textarea.
+
+**Backend coupling:** the `transcode`, `transcode_webm`, `transcode_mkv` ops
+in `ops.go` route through shared `runTranscode` / `runTranscodeVPx` helpers
+that read `crf`, `bitrate`, `preset`, `fps`, `audio_bitrate`, `codec` from
+`OpContext.Args`. Bitrate beats CRF when both are present (the panel
+disables the slider in that case so it's not surprising). Unknown codec
+strings fall through to ffmpeg's own validation — the panel only exposes
+the five we know work.
+
+**Files:**
+
+- `apps/ffmpeg-converter/web/src/components/AdvancedPanel.tsx` — the
+  disclosure component.
+- `apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx` — wires the
+  panel below the dropzone for `operation === 'convert'` rows.
+- `apps/ffmpeg-converter/web/src/components/ToolPage.tsx` — passes
+  `showAdvancedPanel` + `advancedDefaults` from the matrix row.
+- `apps/ffmpeg-converter/web/src/components/url-state.ts` — adds `bitrate`
+  and `codec` to the `convert` whitelist; extends `applyUrlToFfmpegCommand`
+  to substitute CRF / preset / bitrate / audio_bitrate into the displayed
+  command.
+- `apps/ffmpeg-converter/web/src/components/converter-row-args.ts` —
+  forwards `videoBitrate` / `videoCodec` preset hints.
+- `apps/ffmpeg-converter/web/src/ops/types.ts` — `OperationPreset` extension
+  for `videoBitrate` and `videoCodec`.
+- `apps/ffmpeg-converter/ops.go` — `runTranscode` / `runTranscodeVPx`
+  helpers; `transcode` / `transcode_webm` / `transcode_mkv` use them.
+
+**Re-revisit if:** the Advanced-panel open rate (per the metrics list above)
+exceeds 40 %. At that threshold the strategy doc says "promote the panel to
+layer 2" — i.e. show it expanded by default for everyone, not just users who
+opened it once. Below 5 % the simple flow is winning and we should consider
+collapsing the codec/preset distinction further.

--- a/apps/ffmpeg-converter/ops.go
+++ b/apps/ffmpeg-converter/ops.go
@@ -49,6 +49,63 @@ func arg(oc OpContext, key, def string) string {
 	return def
 }
 
+// SEAN-95 — shared transcode runner for the libx264/libx265 family.
+// Reads the Advanced-panel args (`crf`, `bitrate`, `preset`, `fps`,
+// `audio_bitrate`, `codec`) from oc.Args. When `bitrate` is set it overrides
+// CRF (constant-rate-factor and explicit -b:v together is a confusing
+// constrained-quality mode that we don't expose). When `codec` is set it
+// overrides the per-op default (e.g. `transcode` uses libx264 unless the
+// power-user toggle picks libx265).
+func runTranscode(ctx context.Context, oc OpContext, defaultVCodec, defaultACodec, defaultABitrate string) error {
+	vcodec := arg(oc, "codec", defaultVCodec)
+	preset := arg(oc, "preset", "ultrafast")
+	args := []string{"-i", oc.Inputs[0], "-c:v", vcodec, "-preset", preset}
+
+	if br := arg(oc, "bitrate", ""); br != "" {
+		// Bitrate-targeted encode — drop CRF entirely.
+		args = append(args, "-b:v", br)
+	} else {
+		args = append(args, "-crf", arg(oc, "crf", "30"))
+	}
+
+	if fps := arg(oc, "fps", ""); fps != "" {
+		args = append(args, "-r", fps)
+	}
+
+	args = append(args,
+		"-c:a", defaultACodec,
+		"-b:a", arg(oc, "audio_bitrate", defaultABitrate),
+		oc.Output,
+	)
+	return ffmpegRun(ctx, args...)
+}
+
+// SEAN-95 — VP9/Opus-flavoured transcode runner. VP9 doesn't have libx264-style
+// presets; we still accept and ignore the `preset` arg so URL-state round-trips
+// work. CRF is constant-quality mode when paired with `-b:v 0`; explicit
+// bitrate is rate-targeted.
+func runTranscodeVPx(ctx context.Context, oc OpContext, defaultVCodec, defaultACodec, defaultABitrate, defaultBitrate string) error {
+	vcodec := arg(oc, "codec", defaultVCodec)
+	args := []string{"-i", oc.Inputs[0], "-c:v", vcodec, "-deadline", "realtime"}
+
+	if crf := arg(oc, "crf", ""); crf != "" {
+		args = append(args, "-crf", crf, "-b:v", "0")
+	} else {
+		args = append(args, "-b:v", arg(oc, "bitrate", defaultBitrate))
+	}
+
+	if fps := arg(oc, "fps", ""); fps != "" {
+		args = append(args, "-r", fps)
+	}
+
+	args = append(args,
+		"-c:a", defaultACodec,
+		"-b:a", arg(oc, "audio_bitrate", defaultABitrate),
+		oc.Output,
+	)
+	return ffmpegRun(ctx, args...)
+}
+
 // RegisterOps returns the full operation map. The names are deliberately
 // stable — test scripts and any future client both reference these strings.
 func RegisterOps() map[string]*Operation {
@@ -65,32 +122,31 @@ func RegisterOps() map[string]*Operation {
 
 	add(&Operation{
 		Name: "transcode", Category: "video",
-		Description: "Re-container a video; ext=mp4|webm|mkv",
+		Description: "Re-container a video; ext=mp4|webm|mkv. Args: crf, bitrate, preset, fps, audio_bitrate, codec.",
 		DefaultExt:  ".mp4",
 		Run: func(ctx context.Context, oc OpContext) error {
-			return ffmpegRun(ctx, "-i", oc.Inputs[0],
-				"-c:v", "libx264", "-preset", "ultrafast", "-crf", "30",
-				"-c:a", "aac", "-b:a", "64k", oc.Output)
+			return runTranscode(ctx, oc, "libx264", "aac", "64k")
 		},
 	})
 	add(&Operation{
 		Name: "transcode_webm", Category: "video",
-		Description: "Transcode to WebM (VP9 + Opus)",
+		Description: "Transcode to WebM (VP9 + Opus). Args: crf, bitrate, preset, fps, audio_bitrate, codec.",
 		DefaultExt:  ".webm",
 		Run: func(ctx context.Context, oc OpContext) error {
-			return ffmpegRun(ctx, "-i", oc.Inputs[0],
-				"-c:v", "libvpx-vp9", "-b:v", "200k", "-deadline", "realtime",
-				"-c:a", "libopus", "-b:a", "48k", oc.Output)
+			// VP9 has no encoder presets in the libx264 sense, but ffmpeg
+			// accepts -deadline (realtime / good / best) instead. We still
+			// honour the SEAN-95 advanced-panel `bitrate` arg (defaulting
+			// to 200k if unset) and `crf` arg (which VP9 supports as
+			// constant quality when paired with -b:v 0).
+			return runTranscodeVPx(ctx, oc, "libvpx-vp9", "libopus", "48k", "200k")
 		},
 	})
 	add(&Operation{
 		Name: "transcode_mkv", Category: "video",
-		Description: "Remux/transcode to Matroska",
+		Description: "Remux/transcode to Matroska. Args: crf, bitrate, preset, fps, audio_bitrate, codec.",
 		DefaultExt:  ".mkv",
 		Run: func(ctx context.Context, oc OpContext) error {
-			return ffmpegRun(ctx, "-i", oc.Inputs[0],
-				"-c:v", "libx264", "-preset", "ultrafast", "-crf", "30",
-				"-c:a", "aac", "-b:a", "64k", oc.Output)
+			return runTranscode(ctx, oc, "libx264", "aac", "64k")
 		},
 	})
 	add(&Operation{

--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -18,7 +18,8 @@
     "test:result-block": "ts-node -P tsconfig.test.json src/components/__tests__/ResultBlock.test.ts",
     "test:url-state": "ts-node -P tsconfig.test.json src/components/__tests__/url-state.test.ts",
     "test:preset-storage": "ts-node -P tsconfig.test.json src/components/__tests__/preset-storage.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage"
+    "test:advanced-panel": "ts-node -P tsconfig.test.json src/components/__tests__/AdvancedPanel.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage && yarn test:advanced-panel"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/AdvancedPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/AdvancedPanel.tsx
@@ -1,0 +1,484 @@
+'use client';
+
+// SEAN-95 — Layer 3 "Advanced..." disclosure for video convert pages.
+//
+// STRATEGY.md §"Where do fractal options give an edge?" specs a progressive-
+// disclosure layer cake. Layers 0-2 (drop zone, target format, preset) ship
+// as part of the slug-page + homepage flow already. This component is Layer 3
+// — the per-conversion knob panel that power users (developers, podcasters,
+// repeat visitors) need before they go to HandBrake. Hidden by default;
+// remembered as expanded once the user opens it.
+//
+// Controls:
+//   - CRF slider (0-51, default per row)
+//   - Bitrate input (overrides CRF when set)
+//   - Preset dropdown (ultrafast → veryslow)
+//   - FPS override
+//   - Audio bitrate
+//   - Codec selector (hidden behind the "Show everything" power-user toggle)
+//
+// All controls write to URL state — the canonical home for converter options
+// per #93 — so a panel state of `?crf=32&preset=slow&bitrate=2M` is shareable
+// and bookmarkable. The displayed ffmpeg command (above the panel, owned by
+// `<ConverterPanel />` via `applyUrlToFfmpegCommand`) updates live as the
+// user tweaks (Layer 4 of the strategy doc).
+//
+// Backend coupling:
+//   - The `transcode` / `transcode_webm` / `transcode_mkv` ops in `ops.go`
+//     read `crf`, `bitrate`, `preset`, `fps`, `audio_bitrate`, `codec` via
+//     `arg()` — keys here must match the snake_case form on the Go side.
+
+import { useEffect, useMemo, useState } from 'react';
+import {
+  type AdvancedFormState,
+  formStateToUrl,
+  hydrateFormState,
+} from './advanced-panel-state';
+import {
+  applyUrlState,
+  applyUrlToFfmpegCommand,
+  parseUrlState,
+} from './url-state';
+
+export type {
+  AdvancedDefaults,
+  AdvancedFormState,
+} from './advanced-panel-state';
+// Re-exports — call sites that already import from `<AdvancedPanel />` get
+// the pure helpers without a second import. Tests import directly from
+// `./advanced-panel-state` to avoid pulling React into the test runner.
+export {
+  formStateToUrl,
+  hydrateFormState,
+} from './advanced-panel-state';
+
+const PRESET_OPTIONS = [
+  'ultrafast',
+  'superfast',
+  'veryfast',
+  'faster',
+  'fast',
+  'medium',
+  'slow',
+  'slower',
+  'veryslow',
+] as const;
+
+// Codec options the backend understands. Order: most common → niche. The
+// power-user "Show everything" toggle reveals this dropdown; the default-
+// codec inference happens server-side based on the output format.
+const CODEC_OPTIONS = [
+  { value: '', label: 'Auto (format default)' },
+  { value: 'libx264', label: 'H.264 (libx264) — universal' },
+  { value: 'libx265', label: 'H.265 / HEVC (libx265)' },
+  { value: 'libvpx-vp9', label: 'VP9 (libvpx-vp9) — WebM' },
+  { value: 'libaom-av1', label: 'AV1 (libaom-av1) — slow' },
+  { value: 'mpeg4', label: 'MPEG-4 — legacy' },
+] as const;
+
+const LOCAL_STORAGE_KEY = 'ffmpegConverter:advancedPanelExpanded';
+const LOCAL_STORAGE_SHOW_EVERYTHING = 'ffmpegConverter:advancedPanelShowAll';
+
+export interface AdvancedPanelProps {
+  /**
+   * Operation. Used by URL-state read/write — the panel is currently only
+   * mounted for `convert` rows but plumbed in case future ops adopt it.
+   */
+  operation: 'convert';
+  /**
+   * Matrix row's ffmpegCommand template — used for the live "Layer 4"
+   * preview shown at the bottom of the disclosure. Per STRATEGY.md the
+   * command should update live as the user tweaks; we show it inline so
+   * the live-update is visible *before* the conversion runs (not just on
+   * the result row).
+   */
+  ffmpegCommand?: string;
+  /**
+   * Default CRF for this row, sourced from `row.preset.crf` or the matrix
+   * command literal. Used to initialise the slider when no URL value is
+   * present.
+   */
+  defaultCrf?: number;
+  /** Default `-preset` value (e.g. `medium`). */
+  defaultPreset?: string;
+  /** Default video bitrate (e.g. `500k`). Empty = CRF mode. */
+  defaultBitrate?: string;
+  /** Default fps (matches the row's preset.fps if present). */
+  defaultFps?: string;
+  /** Default audio bitrate (e.g. `128k`). */
+  defaultAudioBitrate?: string;
+  /** Default codec — only shown when the power-user toggle is on. */
+  defaultCodec?: string;
+}
+
+function readInitialExpanded(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(LOCAL_STORAGE_KEY) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function readInitialShowAll(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    return window.localStorage.getItem(LOCAL_STORAGE_SHOW_EVERYTHING) === '1';
+  } catch {
+    return false;
+  }
+}
+
+function persistExpanded(expanded: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LOCAL_STORAGE_KEY, expanded ? '1' : '0');
+  } catch {
+    // localStorage may be disabled (private mode, quota exceeded). Silently
+    // give up — disclosure state still works for the current session.
+  }
+}
+
+function persistShowAll(showAll: boolean): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(
+      LOCAL_STORAGE_SHOW_EVERYTHING,
+      showAll ? '1' : '0',
+    );
+  } catch {
+    // ditto.
+  }
+}
+
+export function AdvancedPanel({
+  operation,
+  ffmpegCommand,
+  // Defaults below match the literals baked into the matrix ffmpeg commands
+  // (and the per-op defaults the Go `runTranscode` helper uses when the form
+  // arg is empty). Keep them in sync — a mismatch here means the slider
+  // position lies about what the conversion will actually do.
+  defaultCrf = 30,
+  defaultPreset = 'ultrafast',
+  defaultBitrate = '',
+  defaultFps = '',
+  defaultAudioBitrate = '',
+  defaultCodec = '',
+}: AdvancedPanelProps) {
+  const [expanded, setExpanded] = useState<boolean>(false);
+  const [showAll, setShowAll] = useState<boolean>(false);
+  const [form, setForm] = useState<AdvancedFormState>(() =>
+    hydrateFormState(
+      {},
+      {
+        crf: defaultCrf,
+        preset: defaultPreset,
+        bitrate: defaultBitrate,
+        fps: defaultFps,
+        audio_bitrate: defaultAudioBitrate,
+        codec: defaultCodec,
+      },
+    ),
+  );
+
+  // Hydrate from localStorage + URL on mount. SSR-safe (no-op when `window`
+  // is undefined; React then re-runs the effect on the client).
+  useEffect(() => {
+    setExpanded(readInitialExpanded());
+    setShowAll(readInitialShowAll());
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const url = parseUrlState(params, operation);
+      setForm(
+        hydrateFormState(url, {
+          crf: defaultCrf,
+          preset: defaultPreset,
+          bitrate: defaultBitrate,
+          fps: defaultFps,
+          audio_bitrate: defaultAudioBitrate,
+          codec: defaultCodec,
+        }),
+      );
+    }
+    // Defaults derive from a stable row reference; rerun only when the
+    // operation changes (e.g. between routes during client navigation).
+  }, [
+    operation,
+    defaultCrf,
+    defaultPreset,
+    defaultBitrate,
+    defaultFps,
+    defaultAudioBitrate,
+    defaultCodec,
+  ]);
+
+  const update = (patch: Partial<AdvancedFormState>) => {
+    setForm((prev) => {
+      const next = { ...prev, ...patch };
+      // Mirror the change into the URL so the displayed ffmpeg command (read
+      // by `<ConverterPanel />` via the same URL) updates live and the link
+      // is shareable. Uses replaceState — no history pollution, no scroll.
+      applyUrlState(
+        formStateToUrl(next, { crf: defaultCrf, preset: defaultPreset }),
+        operation,
+      );
+      // replaceState doesn't fire `popstate`, so emit a custom event the
+      // ConverterPanel listens for to re-read URL state. Keeps the read-side
+      // (ConverterPanel) and write-side (AdvancedPanel) decoupled — neither
+      // needs a direct prop wire.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('ffmpeg-converter:url-state'));
+      }
+      return next;
+    });
+  };
+
+  // Live preview of the ffmpeg command — Layer 4 of the strategy doc. Reads
+  // the same `applyUrlToFfmpegCommand` ResultBlock uses so the post-conversion
+  // copy-paste exactly matches what the panel was advertising mid-tweak.
+  // We feed it the form (not the URL) so the preview updates instantly even
+  // before the URL replace has propagated through ConverterPanel's listener.
+  const previewCommand = useMemo(() => {
+    if (!ffmpegCommand) return '';
+    const url = formStateToUrl(form, {
+      crf: defaultCrf,
+      preset: defaultPreset,
+    });
+    // The URL-state has the right keys (crf, bitrate, preset, audio_bitrate)
+    // — `applyUrlToFfmpegCommand` does the substitutions. width/fps don't
+    // currently substitute on convert pages (no `scale=W:-1` in the matrix
+    // string for transcode rows) but the helper handles that no-op cleanly.
+    return applyUrlToFfmpegCommand(ffmpegCommand, url);
+  }, [ffmpegCommand, form, defaultCrf, defaultPreset]);
+
+  const toggleExpanded = () => {
+    setExpanded((prev) => {
+      const next = !prev;
+      persistExpanded(next);
+      return next;
+    });
+  };
+
+  const toggleShowAll = () => {
+    setShowAll((prev) => {
+      const next = !prev;
+      persistShowAll(next);
+      return next;
+    });
+  };
+
+  return (
+    <div className="mt-4 rounded-2xl border border-gray-800 bg-gray-900/40">
+      <button
+        type="button"
+        onClick={toggleExpanded}
+        aria-expanded={expanded}
+        aria-controls="advanced-panel-body"
+        className={[
+          'flex w-full items-center justify-between',
+          'rounded-2xl px-5 py-3 text-left',
+          'text-gray-200 text-sm font-medium',
+          'transition-colors hover:bg-gray-900/70 focus:outline-none focus:ring-2 focus:ring-indigo-500',
+        ].join(' ')}
+      >
+        <span>Advanced</span>
+        <span aria-hidden className="text-gray-500">
+          {expanded ? '▾' : '▸'}
+        </span>
+      </button>
+
+      {expanded && (
+        <div
+          id="advanced-panel-body"
+          className="space-y-5 border-gray-800 border-t px-5 py-5"
+        >
+          {/* CRF slider — the canonical quality knob for libx264/libx265/VP9.
+              0 = lossless, 51 = unwatchable. 23 is the libx264 default. */}
+          <div>
+            <label
+              htmlFor="adv-crf"
+              className="flex items-baseline justify-between text-gray-200 text-sm"
+            >
+              <span>
+                Quality (CRF){form.bitrate && ' — overridden by bitrate'}
+              </span>
+              <span className="text-gray-400 tabular-nums">{form.crf}</span>
+            </label>
+            <input
+              id="adv-crf"
+              type="range"
+              min={0}
+              max={51}
+              step={1}
+              value={form.crf}
+              disabled={Boolean(form.bitrate)}
+              onChange={(e) => update({ crf: e.target.value })}
+              className="mt-2 w-full accent-indigo-500 disabled:opacity-50"
+            />
+            <div className="mt-1 flex justify-between text-gray-500 text-xs">
+              <span>0 — lossless</span>
+              <span>{defaultCrf} — default</span>
+              <span>51 — tiny</span>
+            </div>
+          </div>
+
+          {/* Bitrate input — overrides CRF when set. */}
+          <div>
+            <label
+              htmlFor="adv-bitrate"
+              className="block text-gray-200 text-sm"
+            >
+              Video bitrate (overrides CRF)
+            </label>
+            <input
+              id="adv-bitrate"
+              type="text"
+              placeholder="e.g. 2M, 500k"
+              value={form.bitrate}
+              onChange={(e) => update({ bitrate: e.target.value.trim() })}
+              className={[
+                'mt-2 w-full rounded-lg border border-gray-700 bg-gray-950',
+                'px-3 py-2 text-gray-100 text-sm',
+                'focus:border-indigo-500 focus:outline-none',
+              ].join(' ')}
+            />
+          </div>
+
+          {/* Preset dropdown — speed/compression trade-off. */}
+          <div>
+            <label htmlFor="adv-preset" className="block text-gray-200 text-sm">
+              Encoder preset
+            </label>
+            <select
+              id="adv-preset"
+              value={form.preset}
+              onChange={(e) => update({ preset: e.target.value })}
+              className={[
+                'mt-2 w-full rounded-lg border border-gray-700 bg-gray-950',
+                'px-3 py-2 text-gray-100 text-sm',
+                'focus:border-indigo-500 focus:outline-none',
+              ].join(' ')}
+            >
+              {PRESET_OPTIONS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* FPS override. */}
+          <div>
+            <label htmlFor="adv-fps" className="block text-gray-200 text-sm">
+              Frame rate (fps) — leave blank for source rate
+            </label>
+            <input
+              id="adv-fps"
+              type="text"
+              inputMode="numeric"
+              placeholder="e.g. 30"
+              value={form.fps}
+              onChange={(e) => update({ fps: e.target.value.trim() })}
+              className={[
+                'mt-2 w-full rounded-lg border border-gray-700 bg-gray-950',
+                'px-3 py-2 text-gray-100 text-sm',
+                'focus:border-indigo-500 focus:outline-none',
+              ].join(' ')}
+            />
+          </div>
+
+          {/* Audio bitrate. */}
+          <div>
+            <label
+              htmlFor="adv-audio-bitrate"
+              className="block text-gray-200 text-sm"
+            >
+              Audio bitrate
+            </label>
+            <input
+              id="adv-audio-bitrate"
+              type="text"
+              placeholder="e.g. 128k"
+              value={form.audio_bitrate}
+              onChange={(e) => update({ audio_bitrate: e.target.value.trim() })}
+              className={[
+                'mt-2 w-full rounded-lg border border-gray-700 bg-gray-950',
+                'px-3 py-2 text-gray-100 text-sm',
+                'focus:border-indigo-500 focus:outline-none',
+              ].join(' ')}
+            />
+          </div>
+
+          {/* Power-user toggle. Hidden behind disclosure so casual users
+              never see it; pre-checked is too aggressive. */}
+          <div className="flex items-center gap-2 border-gray-800 border-t pt-4">
+            <input
+              id="adv-show-all"
+              type="checkbox"
+              checked={showAll}
+              onChange={toggleShowAll}
+              className="h-4 w-4 accent-indigo-500"
+            />
+            <label
+              htmlFor="adv-show-all"
+              className="text-gray-300 text-sm select-none"
+            >
+              Show everything (codec selector, etc.)
+            </label>
+          </div>
+
+          {/* Codec selector — only when "Show everything" is on. STRATEGY.md
+              line 119: "pix_fmt only for power users who toggled a 'show
+              everything' checkbox". Same rule for codec. */}
+          {showAll && (
+            <div>
+              <label
+                htmlFor="adv-codec"
+                className="block text-gray-200 text-sm"
+              >
+                Video codec
+              </label>
+              <select
+                id="adv-codec"
+                value={form.codec}
+                onChange={(e) => update({ codec: e.target.value })}
+                className={[
+                  'mt-2 w-full rounded-lg border border-gray-700 bg-gray-950',
+                  'px-3 py-2 text-gray-100 text-sm',
+                  'focus:border-indigo-500 focus:outline-none',
+                ].join(' ')}
+              >
+                {CODEC_OPTIONS.map((c) => (
+                  <option key={c.value || 'auto'} value={c.value}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {/* Live ffmpeg command preview — Layer 4 of the strategy doc. Updates
+              instantly as the user tweaks any control above. The same string
+              flows through to the post-conversion result row so copy-paste
+              users see exactly what was advertised. */}
+          {previewCommand && (
+            <div className="border-gray-800 border-t pt-4">
+              <div className="mb-2 text-gray-400 text-xs uppercase tracking-wider">
+                Live ffmpeg command
+              </div>
+              <pre
+                aria-label="Live ffmpeg command preview"
+                className={[
+                  'overflow-x-auto rounded-lg border border-gray-800 bg-gray-950',
+                  'px-3 py-2 text-gray-200 text-xs leading-relaxed',
+                ].join(' ')}
+              >
+                <code>{previewCommand}</code>
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -27,6 +27,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { Operation } from '@/ops/types';
+import { AdvancedPanel } from './AdvancedPanel';
 import { type ConversionJob, DropZone } from './DropZone';
 import {
   deletePreset as deletePresetFromStorage,
@@ -72,6 +73,26 @@ export interface ConverterPanelProps {
    */
   operation?: Operation;
   /**
+   * SEAN-95 — when true (video `convert` rows only) the panel renders the
+   * Layer-3 Advanced disclosure below the dropzone. Per-row defaults flow
+   * via `advancedDefaults`.
+   */
+  showAdvancedPanel?: boolean;
+  /**
+   * SEAN-95 — defaults for the Advanced panel's controls. Sourced from the
+   * matrix row's `preset` (CRF + preset name) plus parsed-out hints from
+   * the displayed ffmpeg command (so the slider position matches what the
+   * copy-paste command shows on first paint).
+   */
+  advancedDefaults?: {
+    crf?: number;
+    preset?: string;
+    bitrate?: string;
+    fps?: string;
+    audio_bitrate?: string;
+    codec?: string;
+  };
+  /**
    * SEAN-75: pre-loaded file forwarded from the homepage drop zone. When set,
    * `<DropZone />` auto-fires the upload on mount so the user reaches the
    * converting/result UI without dropping a second time.
@@ -97,6 +118,8 @@ export function ConverterPanel({
   reverseLabel,
   reverseOperation,
   operation,
+  showAdvancedPanel,
+  advancedDefaults,
   initialFile,
   onReset,
 }: ConverterPanelProps) {
@@ -135,6 +158,41 @@ export function ConverterPanel({
     [ffmpegCommand, urlState],
   );
 
+  // SEAN-95 — Advanced disclosure. Mounted below the converter panel for
+  // video `convert` rows only. The panel itself is a pure URL-state writer:
+  // no callback up to the parent, the URL is the single source of truth and
+  // ConverterPanel re-reads on the resulting popstate / its own mount.
+  // BUT: replaceState doesn't fire popstate, so we expose a state-setter so
+  // AdvancedPanel can also push the change directly into urlState here. We
+  // wrap that into a child-callback to keep the URL ↔ React loop tight.
+  const advanced =
+    showAdvancedPanel && operation === 'convert' ? (
+      <AdvancedPanel
+        operation="convert"
+        ffmpegCommand={ffmpegCommand}
+        defaultCrf={advancedDefaults?.crf}
+        defaultPreset={advancedDefaults?.preset}
+        defaultBitrate={advancedDefaults?.bitrate}
+        defaultFps={advancedDefaults?.fps}
+        defaultAudioBitrate={advancedDefaults?.audio_bitrate}
+        defaultCodec={advancedDefaults?.codec}
+      />
+    ) : null;
+
+  // Re-sync urlState after Advanced panel writes — replaceState doesn't fire
+  // popstate, so we listen on a custom event the panel emits when it writes.
+  useEffect(() => {
+    if (typeof window === 'undefined' || !operation) return;
+    const onChange = () => {
+      const params = new URLSearchParams(window.location.search);
+      setUrlState(parseUrlState(params, operation));
+    };
+    window.addEventListener('ffmpeg-converter:url-state', onChange);
+    return () => {
+      window.removeEventListener('ffmpeg-converter:url-state', onChange);
+    };
+  }, [operation]);
+
   if (!job) {
     return (
       <>
@@ -158,21 +216,25 @@ export function ConverterPanel({
           onJobComplete={setJob}
           initialFile={initialFile}
         />
+        {advanced}
       </>
     );
   }
   return (
-    <ResultBlock
-      job={job}
-      ffmpegCommand={displayedCommand}
-      reverseSlug={reverseSlug}
-      reverseLabel={reverseLabel}
-      reverseOperation={reverseOperation}
-      onReset={() => {
-        setJob(null);
-        onReset?.();
-      }}
-    />
+    <>
+      <ResultBlock
+        job={job}
+        ffmpegCommand={displayedCommand}
+        reverseSlug={reverseSlug}
+        reverseLabel={reverseLabel}
+        reverseOperation={reverseOperation}
+        onReset={() => {
+          setJob(null);
+          onReset?.();
+        }}
+      />
+      {advanced}
+    </>
   );
 }
 

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -121,6 +121,25 @@ export function ToolPage({ row, page }: ToolPageProps) {
             reverseLabel={reverse?.label}
             reverseOperation={reverse?.operation}
             operation={row.operation}
+            // SEAN-95 — Advanced disclosure for video convert pages. Image-
+            // convert and other operations get their own (eventually) panel
+            // shape; this one targets the libx264/libx265/VP9 knobs.
+            showAdvancedPanel={row.operation === 'convert'}
+            advancedDefaults={
+              row.operation === 'convert'
+                ? {
+                    crf: row.preset?.crf,
+                    preset: row.preset?.preset,
+                    bitrate: row.preset?.videoBitrate,
+                    fps:
+                      row.preset?.fps !== undefined
+                        ? String(row.preset.fps)
+                        : undefined,
+                    audio_bitrate: row.preset?.audioBitrate,
+                    codec: row.preset?.videoCodec,
+                  }
+                : undefined
+            }
           />
         )}
       </section>

--- a/apps/ffmpeg-converter/web/src/components/__tests__/AdvancedPanel.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/AdvancedPanel.test.ts
@@ -1,0 +1,269 @@
+/**
+ * SEAN-95 — Advanced disclosure panel for video convert pages.
+ *
+ * The panel itself is JSX (mounted by ConverterPanel for `convert` rows) so
+ * we can't test the disclosure UI from `node --test` without a JSDOM. What
+ * we CAN test (and what bears the risk):
+ *
+ *   1. `hydrateFormState` — URL > defaults override order, missing fields
+ *      pull from defaults, defaults missing → empty string (matches the
+ *      input element shape).
+ *   2. `formStateToUrl` — empty fields drop, default CRF drops (so URL
+ *      stays minimal), URL contains only explicit overrides.
+ *   3. URL whitelist — `convert` accepts the new `bitrate` and `codec`
+ *      keys after this ticket; `gif` and `compress` continue to reject
+ *      both. (Defence-in-depth against regressions to the whitelist.)
+ *   4. ffmpeg command rewriting — CRF / preset / bitrate / audio_bitrate
+ *      substitutions hit the actual matrix command for `mov-to-mp4`.
+ *
+ * Test runner: `node --test` via ts-node (matches the rest of the suite).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { MATRIX_BY_SLUG } from '../../ops/matrix';
+import { formStateToUrl, hydrateFormState } from '../advanced-panel-state';
+import {
+  applyUrlToFfmpegCommand,
+  parseUrlState,
+  URL_PARAM_WHITELIST,
+} from '../url-state';
+
+describe('SEAN-95 AdvancedPanel — hydrateFormState', () => {
+  const defaults = {
+    crf: 23,
+    preset: 'medium',
+    bitrate: '',
+    fps: '',
+    audio_bitrate: '',
+    codec: '',
+  };
+
+  it('falls through to defaults when URL state is empty', () => {
+    const out = hydrateFormState({}, defaults);
+    assert.equal(out.crf, '23');
+    assert.equal(out.preset, 'medium');
+    assert.equal(out.bitrate, '');
+    assert.equal(out.fps, '');
+    assert.equal(out.audio_bitrate, '');
+    assert.equal(out.codec, '');
+  });
+
+  it('lets URL values override defaults per-field', () => {
+    const out = hydrateFormState(
+      { crf: '32', bitrate: '2M', codec: 'libx265' },
+      defaults,
+    );
+    assert.equal(out.crf, '32', 'URL crf must win');
+    assert.equal(out.bitrate, '2M');
+    assert.equal(out.codec, 'libx265');
+    // Untouched fields keep defaults.
+    assert.equal(out.preset, 'medium');
+    assert.equal(out.fps, '');
+    assert.equal(out.audio_bitrate, '');
+  });
+
+  it('preserves default CRF as a string (matches the slider value attr)', () => {
+    // The slider value attribute is a string; the form state mirrors that
+    // so React doesn't re-render the input on every change.
+    const out = hydrateFormState({}, defaults);
+    assert.equal(typeof out.crf, 'string');
+  });
+});
+
+describe('SEAN-95 AdvancedPanel — formStateToUrl', () => {
+  const defaults = { crf: 23, preset: 'medium' };
+
+  it('returns an empty object when nothing is customised', () => {
+    const out = formStateToUrl(
+      {
+        crf: '23',
+        preset: 'medium',
+        bitrate: '',
+        fps: '',
+        audio_bitrate: '',
+        codec: '',
+      },
+      defaults,
+    );
+    assert.deepEqual(out, {});
+  });
+
+  it('drops the default CRF (so URL stays clean)', () => {
+    // Critical: every render of the panel mounts with crf=defaultCrf in the
+    // form state. We must NOT push that into the URL — otherwise navigating
+    // to `/convert/mov-to-mp4` once writes `?crf=23` into the bar before the
+    // user has touched anything.
+    const out = formStateToUrl(
+      {
+        crf: '23',
+        preset: 'medium',
+        bitrate: '',
+        fps: '',
+        audio_bitrate: '',
+        codec: '',
+      },
+      defaults,
+    );
+    assert.equal(out.crf, undefined);
+  });
+
+  it('keeps non-default CRF', () => {
+    const out = formStateToUrl(
+      {
+        crf: '32',
+        preset: 'medium',
+        bitrate: '',
+        fps: '',
+        audio_bitrate: '',
+        codec: '',
+      },
+      defaults,
+    );
+    assert.equal(out.crf, '32');
+  });
+
+  it('writes bitrate even when defaults lack one', () => {
+    const out = formStateToUrl(
+      {
+        crf: '23',
+        preset: 'medium',
+        bitrate: '2M',
+        fps: '',
+        audio_bitrate: '',
+        codec: '',
+      },
+      defaults,
+    );
+    assert.equal(out.bitrate, '2M');
+    // CRF is at default — drops out per the contract above.
+    assert.equal(out.crf, undefined);
+  });
+
+  it('writes codec only when explicitly chosen', () => {
+    const empty = formStateToUrl(
+      {
+        crf: '23',
+        preset: 'medium',
+        bitrate: '',
+        fps: '',
+        audio_bitrate: '',
+        codec: '',
+      },
+      defaults,
+    );
+    assert.equal(empty.codec, undefined);
+
+    const set = formStateToUrl(
+      {
+        crf: '23',
+        preset: 'medium',
+        bitrate: '',
+        fps: '',
+        audio_bitrate: '',
+        codec: 'libx265',
+      },
+      defaults,
+    );
+    assert.equal(set.codec, 'libx265');
+  });
+});
+
+describe('SEAN-95 url-state — convert whitelist extension', () => {
+  it('accepts bitrate and codec on convert pages', () => {
+    const state = parseUrlState(
+      'crf=32&bitrate=2M&codec=libx265&preset=slow&fps=30&audio_bitrate=128k',
+      'convert',
+    );
+    assert.equal(state.crf, '32');
+    assert.equal(state.bitrate, '2M');
+    assert.equal(state.codec, 'libx265');
+    assert.equal(state.preset, 'slow');
+    assert.equal(state.fps, '30');
+    assert.equal(state.audio_bitrate, '128k');
+  });
+
+  it('rejects bitrate/codec on non-convert operations (gif still tight)', () => {
+    const gifState = parseUrlState('bitrate=2M&codec=libx265&fps=24', 'gif');
+    assert.equal(gifState.bitrate, undefined);
+    assert.equal(gifState.codec, undefined);
+    // fps still works on gif (it's in the gif whitelist).
+    assert.equal(gifState.fps, '24');
+  });
+
+  it('whitelist for convert lists exactly the expected keys', () => {
+    const expected = [
+      'crf',
+      'bitrate',
+      'preset',
+      'audio_bitrate',
+      'resolution',
+      'fps',
+      'codec',
+    ];
+    assert.deepEqual(
+      [...URL_PARAM_WHITELIST.convert].sort(),
+      [...expected].sort(),
+    );
+  });
+});
+
+describe('SEAN-95 url-state — applyUrlToFfmpegCommand extensions', () => {
+  it('rewrites CRF on the mov-to-mp4 flagship command', () => {
+    const row = MATRIX_BY_SLUG['mov-to-mp4'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, { crf: '32' });
+    assert.match(out, /-crf 32/);
+    assert.doesNotMatch(out, /-crf 30/);
+  });
+
+  it('rewrites preset on the mov-to-mp4 flagship command', () => {
+    const row = MATRIX_BY_SLUG['mov-to-mp4'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, { preset: 'slow' });
+    assert.match(out, /-preset slow/);
+    assert.doesNotMatch(out, /-preset ultrafast/);
+  });
+
+  it('bitrate replaces existing -b:v on the mp4-to-webm command', () => {
+    const row = MATRIX_BY_SLUG['mp4-to-webm'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, { bitrate: '500k' });
+    assert.match(out, /-b:v 500k/);
+    assert.doesNotMatch(out, /-b:v 200k/);
+  });
+
+  it('bitrate inserts -b:v and drops -crf on a CRF-mode command', () => {
+    const row = MATRIX_BY_SLUG['mov-to-mp4'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, { bitrate: '2M' });
+    assert.match(out, /-b:v 2M/);
+    assert.doesNotMatch(out, /-crf/);
+    // -preset survives — it's still meaningful with bitrate-targeted encoding.
+    assert.match(out, /-preset/);
+  });
+
+  it('audio_bitrate rewrites -b:a', () => {
+    const row = MATRIX_BY_SLUG['mov-to-mp4'];
+    assert.ok(row);
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, {
+      audio_bitrate: '192k',
+    });
+    assert.match(out, /-b:a 192k/);
+    assert.doesNotMatch(out, /-b:a 64k/);
+  });
+
+  it('combined CRF + preset matches the AC test for mov-to-mp4', () => {
+    // Ticket AC: setting CRF=32 on `/convert/mov-to-mp4` produces a different
+    // command than default CRF=30. The displayed command is the user-visible
+    // contract — if it says CRF=32, the backend MUST run CRF=32. This is the
+    // round-trip test from URL → command.
+    const row = MATRIX_BY_SLUG['mov-to-mp4'];
+    assert.ok(row);
+    const state = parseUrlState('crf=32&preset=slow', 'convert');
+    const out = applyUrlToFfmpegCommand(row.ffmpegCommand, state);
+    assert.match(out, /-crf 32/);
+    assert.match(out, /-preset slow/);
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/advanced-panel-state.ts
+++ b/apps/ffmpeg-converter/web/src/components/advanced-panel-state.ts
@@ -1,0 +1,70 @@
+// SEAN-95 — Pure state helpers for the Advanced disclosure panel.
+//
+// Lives outside the .tsx file so the test runner (`node --test` via ts-node,
+// no JSDOM) can import these without dragging React in. The .tsx component
+// re-exports for ergonomic imports at call sites that already use the
+// component.
+
+import type { UrlState } from './url-state';
+
+export interface AdvancedFormState {
+  crf: string;
+  bitrate: string;
+  preset: string;
+  fps: string;
+  audio_bitrate: string;
+  codec: string;
+}
+
+export interface AdvancedDefaults {
+  crf: number;
+  preset: string;
+  bitrate: string;
+  fps: string;
+  audio_bitrate: string;
+  codec: string;
+}
+
+/**
+ * Hydrate form state from a URL-state snapshot, falling back to per-row
+ * defaults. Pure, testable. URL > defaults (ConverterPanel handles row
+ * preset → defaults; this layer just merges URL on top).
+ */
+export function hydrateFormState(
+  urlState: UrlState,
+  defaults: AdvancedDefaults,
+): AdvancedFormState {
+  return {
+    crf: urlState.crf ?? String(defaults.crf),
+    bitrate: urlState.bitrate ?? defaults.bitrate,
+    preset: urlState.preset ?? defaults.preset,
+    fps: urlState.fps ?? defaults.fps,
+    audio_bitrate: urlState.audio_bitrate ?? defaults.audio_bitrate,
+    codec: urlState.codec ?? defaults.codec,
+  };
+}
+
+/**
+ * Build the URL-state object from the form. Empty fields drop out entirely
+ * so the URL stays minimal — only non-default explicit overrides survive.
+ *
+ * CRF default special-case: when the form's CRF matches the row default AND
+ * no bitrate is set, we drop CRF from the URL too. Otherwise every page load
+ * would write the default CRF back into the URL on first interaction, which
+ * is noisy and breaks the "URL stays clean unless you customise" contract.
+ *
+ * Same rule for preset (drops when matching the row default).
+ */
+export function formStateToUrl(
+  form: AdvancedFormState,
+  defaults: { crf: number; preset: string },
+): UrlState {
+  const out: Record<string, string> = {};
+  if (form.crf && form.crf !== String(defaults.crf)) out.crf = form.crf;
+  if (form.bitrate) out.bitrate = form.bitrate;
+  if (form.preset && form.preset !== defaults.preset) out.preset = form.preset;
+  if (form.fps) out.fps = form.fps;
+  if (form.audio_bitrate) out.audio_bitrate = form.audio_bitrate;
+  if (form.codec) out.codec = form.codec;
+  return out;
+}

--- a/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
+++ b/apps/ffmpeg-converter/web/src/components/converter-row-args.ts
@@ -86,6 +86,11 @@ export function buildExtraArgs(
   if (p.trimDurationSec !== undefined) {
     args.duration = String(p.trimDurationSec);
   }
+  // SEAN-95 — Advanced disclosure preset hints. `videoBitrate` becomes the
+  // backend `bitrate` arg; `videoCodec` becomes the backend `codec` arg.
+  // Both stay snake_case-ish on the wire to match the Go op's `arg()` keys.
+  if (p.videoBitrate !== undefined) args.bitrate = p.videoBitrate;
+  if (p.videoCodec !== undefined) args.codec = p.videoCodec;
   return Object.keys(args).length > 0 ? args : undefined;
 }
 

--- a/apps/ffmpeg-converter/web/src/components/url-state.ts
+++ b/apps/ffmpeg-converter/web/src/components/url-state.ts
@@ -45,7 +45,18 @@ import type { Operation } from '@/ops/types';
  * not raw form fields.
  */
 export const URL_PARAM_WHITELIST: Record<Operation, readonly string[]> = {
-  convert: ['crf', 'preset', 'audio_bitrate', 'resolution', 'fps'],
+  // SEAN-95 — convert adds `bitrate` and `codec` for the advanced disclosure
+  // panel. `bitrate` overrides CRF when set; `codec` is hidden by default and
+  // only revealed via the "Show everything" power-user toggle.
+  convert: [
+    'crf',
+    'bitrate',
+    'preset',
+    'audio_bitrate',
+    'resolution',
+    'fps',
+    'codec',
+  ],
   compress: ['crf', 'preset', 'target_size_mb', 'audio_bitrate', 'resolution'],
   'extract-audio': ['audio_bitrate'],
   'extract-frames': ['fps', 'width'],
@@ -183,16 +194,21 @@ export function mergeUrlIntoExtraArgs(
  * displayed command reflects what will actually run.
  *
  * The matrix authors ffmpeg commands with literal preset values baked in
- * (e.g. `fps=10,scale=480:-1` for the GIF flagship row). When the user
- * overrides via URL params we patch those literals so the copy-paste command
- * stays accurate. Scope is intentionally narrow:
- *   - `fps=N` → replaces `fps=<digits>` everywhere in the command
- *   - `width=N` → replaces `scale=<digits>:-1` and `scale=<digits>:<anything>`
+ * (e.g. `fps=10,scale=480:-1` for the GIF flagship row, or `-crf 30
+ * -preset ultrafast` for the convert flagship). When the user overrides via
+ * URL params we patch those literals so the copy-paste command stays
+ * accurate. Scope:
+ *   - `fps=N`        → replaces `fps=<digits>` (filter-graph form, gif/preview)
+ *   - `width=N`      → replaces `scale=<digits>:-1` / `scale=<digits>:<digits>`
+ *   - `crf=N`        → replaces `-crf <digits>`
+ *   - `preset=X`     → replaces `-preset <word>`
+ *   - `bitrate=X`    → replaces `-b:v <value>` (and inserts when CRF is
+ *     replaced by bitrate-targeted encoding — see SEAN-95)
+ *   - `audio_bitrate=X` → replaces `-b:a <value>`
  *
- * Anything else (CRF, bitrate, etc.) is forwarded to the backend via
- * extraArgs but the ffmpeg command keeps its original literal — Phase 2 of
- * URL-state will extend this list once a wider set of advanced controls
- * actually exists in the UI.
+ * Anything else (codec selector, etc.) is forwarded to the backend via
+ * extraArgs but the displayed command keeps its original literal until the
+ * matrix command needs it.
  */
 export function applyUrlToFfmpegCommand(
   template: string,
@@ -206,6 +222,37 @@ export function applyUrlToFfmpegCommand(
     // Match `scale=<digits>:-1` and `scale=<digits>:<digits>` (the two shapes
     // the matrix uses today) without touching the height side.
     out = out.replace(/scale=\d+:(-?\d+)/g, `scale=${state.width}:$1`);
+  }
+  if (state.crf) {
+    out = out.replace(/-crf\s+\d+/g, `-crf ${state.crf}`);
+  }
+  if (state.preset) {
+    // Replace any `-preset <word>` (the libx264/libx265 preset). Won't touch
+    // `-preset:v` or other variants — none of the matrix commands use them.
+    out = out.replace(
+      /-preset\s+(ultrafast|superfast|veryfast|faster|fast|medium|slow|slower|veryslow)/g,
+      `-preset ${state.preset}`,
+    );
+  }
+  if (state.bitrate) {
+    // When the user supplies an explicit bitrate the encoder switches off
+    // CRF (`-crf` + `-b:v` together is a constrained-quality mode that's
+    // surprising to users). Strip the CRF flag so the command reflects the
+    // actual bitrate-targeted encode.
+    if (/-b:v\s+\S+/.test(out)) {
+      out = out.replace(/-b:v\s+\S+/g, `-b:v ${state.bitrate}`);
+    } else {
+      // Insert `-b:v X` after `-c:v <codec>` (or `-c:v <codec> -preset Y`).
+      // Drop the `-crf N` literal since bitrate takes over.
+      out = out.replace(/-crf\s+\d+\s*/g, '');
+      out = out.replace(
+        /(-c:v\s+\S+(?:\s+-preset\s+\S+)?)/,
+        `$1 -b:v ${state.bitrate}`,
+      );
+    }
+  }
+  if (state.audio_bitrate) {
+    out = out.replace(/-b:a\s+\S+/g, `-b:a ${state.audio_bitrate}`);
   }
   return out;
 }

--- a/apps/ffmpeg-converter/web/src/ops/types.ts
+++ b/apps/ffmpeg-converter/web/src/ops/types.ts
@@ -285,6 +285,20 @@ export interface OperationPreset {
    * Absent = use full remaining input.
    */
   trimDurationSec?: number;
+  /**
+   * SEAN-95 — explicit video bitrate (`500k`, `2M`, etc.). When set on the
+   * row this becomes the default value in the Advanced panel's bitrate field;
+   * the user can override per-conversion via URL state. Bitrate overrides
+   * CRF on the backend when both are present.
+   */
+  videoBitrate?: string;
+  /**
+   * SEAN-95 — explicit video codec name (`libx264`, `libx265`, `libvpx-vp9`,
+   * etc.). Hidden behind the "Show everything" power-user toggle; the
+   * format-appropriate codec is chosen automatically by the backend op when
+   * this is unset.
+   */
+  videoCodec?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #95

## Summary

- Adds a Layer-3 "Advanced" disclosure on `/convert/[slug]` video pages with CRF slider (0-51), bitrate input (overrides CRF), preset dropdown (ultrafast → veryslow), fps override, audio bitrate, plus a codec selector hidden behind a "Show everything" power-user toggle.
- All controls write to URL state via #93 (`?crf=32&preset=slow&bitrate=2M`) so links are shareable; disclosure expanded-state is persisted in `localStorage` so power users get it pre-expanded on return.
- Live ffmpeg command preview (Layer 4) renders inside the disclosure and updates instantly as the user tweaks.
- Backend `transcode` / `transcode_webm` / `transcode_mkv` ops route through new `runTranscode` / `runTranscodeVPx` helpers that read `crf`, `bitrate`, `preset`, `fps`, `audio_bitrate`, `codec` from `OpContext.Args`. Bitrate overrides CRF when both are set.
- Decision record appended to `apps/ffmpeg-converter/docs/STRATEGY.md` covering the six-control set and the codec-behind-toggle rationale.

## Test plan

- [x] `yarn test` (web): all 17 new AdvancedPanel tests + 21 url-state tests + 79 other tests pass
- [x] `npx tsc --noEmit` (web): clean
- [x] `go build ./...` and `go test ./...` (ffmpeg-converter): pass
- [x] `yarn build` (web): all 200+ static pages build successfully
- [ ] Manual: navigate to `/convert/mov-to-mp4`, expand Advanced, drag CRF to 32, confirm URL updates to `?crf=32` and live ffmpeg preview shows `-crf 32`
- [ ] Manual: drop a small MOV with default CRF=30 then again with CRF=32, confirm second output is meaningfully smaller
- [ ] Manual: enable "Show everything", pick `libx265`, confirm command preview switches to `-c:v libx265`
- [ ] Manual: refresh page after expanding panel, confirm panel stays expanded (localStorage)