### PR TITLE
[SEAN-105] feat: drop accept= attribute, panel detects input type and adapts in place

### DIFF
--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -19,7 +19,8 @@
     "test:url-state": "ts-node -P tsconfig.test.json src/components/__tests__/url-state.test.ts",
     "test:preset-storage": "ts-node -P tsconfig.test.json src/components/__tests__/preset-storage.test.ts",
     "test:advanced-panel": "ts-node -P tsconfig.test.json src/components/__tests__/AdvancedPanel.test.ts",
-    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage && yarn test:advanced-panel"
+    "test:converter-panel": "ts-node -P tsconfig.test.json src/components/__tests__/ConverterPanel.test.ts",
+    "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage && yarn test:advanced-panel && yarn test:converter-panel"
   },
   "dependencies": {
     "next": "15.1.6",

--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -26,8 +26,13 @@
 // `./preset-storage.ts` so this file stays focused on the rendering logic.
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { Operation } from '@/ops/types';
+import type { Format, Operation, OperationRow } from '@/ops/types';
 import { AdvancedPanel } from './AdvancedPanel';
+import {
+  buildAcceptLabel,
+  buildExtraArgs,
+  formatToExt,
+} from './converter-row-args';
 import { type ConversionJob, DropZone } from './DropZone';
 import {
   deletePreset as deletePresetFromStorage,
@@ -39,6 +44,8 @@ import {
   savePreset as savePresetToStorage,
 } from './preset-storage';
 import { ResultBlock } from './ResultBlock';
+import { adaptiveRowForFile } from './route-for-file';
+import { pathForSlug } from './route-registry';
 import {
   applyUrlState,
   applyUrlToFfmpegCommand,
@@ -105,6 +112,22 @@ export interface ConverterPanelProps {
    * panel sitting on the homepage.
    */
   onReset?: () => void;
+  /**
+   * SEAN-105: slug-page seed for the adaptive panel. When set the panel runs
+   * `adaptiveRowForFile` on every drop and swaps `detectedRow` if the
+   * resolved row differs. The drop zone's hard-coded `goOp` / `outputExt` /
+   * `extraArgs` props become the *initial* defaults, but `detectedRow`
+   * overrides them after the first drop. The URL slug is updated via
+   * `history.replaceState` (no `router.push` — preserves the in-flight File
+   * object and the panel state).
+   *
+   * Hub pages and the homepage embed don't pass this — they keep the existing
+   * locked-row behaviour. Only `<ToolPage />` (slug pages) wires it.
+   */
+  slugDefault?: {
+    row: OperationRow;
+    inputFormat: Format;
+  };
 }
 
 export function ConverterPanel({
@@ -122,8 +145,19 @@ export function ConverterPanel({
   advancedDefaults,
   initialFile,
   onReset,
+  slugDefault,
 }: ConverterPanelProps) {
   const [job, setJob] = useState<ConversionJob | null>(null);
+
+  // SEAN-105: detected-row state for the adaptive panel. Initialised from the
+  // slug default; replaced when the user drops a file whose detected input
+  // type maps to a different matrix row (e.g. dropping a `.mov` on the
+  // `mp4-to-gif` page swaps to the `mov-to-gif` row). When unset (no
+  // `slugDefault` passed by the parent) the panel falls back to the existing
+  // hard-coded prop behaviour.
+  const [detectedRow, setDetectedRow] = useState<OperationRow | null>(
+    slugDefault?.row ?? null,
+  );
 
   // SEAN-93 — initial URL-state snapshot, read on mount. SSR-safe (returns
   // empty when `window` is undefined). Subscribes to `popstate` so the
@@ -145,17 +179,82 @@ export function ConverterPanel({
     };
   }, [operation]);
 
-  // Merge URL state into the row's preset-derived extraArgs (URL wins) and
-  // substitute the same values into the displayed ffmpeg command so a copy-
-  // paste of the command matches what the backend will run. Both are memoised
-  // so DropZone's effect deps stay stable when nothing changed.
+  // SEAN-105: when the dropped file's detected row differs from the slug
+  // default, all the row-derived knobs (goOp, outputExt, extraArgs, ffmpeg
+  // command, accept label) re-derive from the detected row instead of the
+  // props. The slug default IS the detected row on first paint, so before any
+  // drop the effective values match the props 1:1.
+  const detectedSwapped =
+    detectedRow !== null && detectedRow.slug !== slugDefault?.row.slug;
+  const effectiveGoOp = detectedSwapped ? detectedRow.goOp : goOp;
+  const effectiveOutputExt = detectedSwapped
+    ? formatToExt(detectedRow.outputFormat)
+    : outputExt;
+  const effectiveExtraArgs = detectedSwapped
+    ? buildExtraArgs(detectedRow)
+    : extraArgs;
+  const effectiveFfmpegCommand = detectedSwapped
+    ? detectedRow.ffmpegCommand
+    : ffmpegCommand;
+  const effectiveAcceptLabel = detectedSwapped
+    ? buildAcceptLabel(detectedRow)
+    : acceptLabel;
+
+  // Merge URL state into the (possibly-swapped) row's preset-derived extraArgs
+  // (URL wins) and substitute the same values into the displayed ffmpeg
+  // command so a copy-paste of the command matches what the backend will run.
   const mergedExtraArgs = useMemo(
-    () => mergeUrlIntoExtraArgs(extraArgs, urlState),
-    [extraArgs, urlState],
+    () => mergeUrlIntoExtraArgs(effectiveExtraArgs, urlState),
+    [effectiveExtraArgs, urlState],
   );
   const displayedCommand = useMemo(
-    () => applyUrlToFfmpegCommand(ffmpegCommand, urlState),
-    [ffmpegCommand, urlState],
+    () => applyUrlToFfmpegCommand(effectiveFfmpegCommand, urlState),
+    [effectiveFfmpegCommand, urlState],
+  );
+
+  // SEAN-105: per-file argument resolver passed into DropZone. Runs
+  // `adaptiveRowForFile` synchronously on every drop. If the resolved row
+  // differs from `detectedRow`, the panel swaps and `history.replaceState`
+  // updates the URL slug — but the in-flight conversion uses the resolved
+  // row's args directly (returned from this callback) so React's async state
+  // update doesn't race the imminent submit.
+  const resolveArgsForFile = useCallback(
+    (file: File) => {
+      if (!slugDefault) return null;
+      const currentRow = detectedRow ?? slugDefault.row;
+      const match = adaptiveRowForFile(
+        file,
+        currentRow.operation,
+        currentRow.outputFormat,
+      );
+      if (!match) return null;
+      if (match.row.slug === currentRow.slug) return null;
+
+      // Swap detected row + URL slug. The state update is async (React
+      // batches it for after the current event loop tick) so we ALSO return
+      // the resolved args so DropZone's `submitConversion` doesn't fire with
+      // the stale `goOp` / `outputExt` props.
+      setDetectedRow(match.row);
+      if (typeof window !== 'undefined') {
+        const newPath = pathForSlug(match.row.slug);
+        if (newPath && newPath !== window.location.pathname) {
+          // `history.replaceState` per AC — never `router.push`. Preserves
+          // the in-flight File object and avoids a Next.js re-mount of the
+          // page tree (which would tear down this component).
+          window.history.replaceState(
+            null,
+            '',
+            newPath + window.location.search,
+          );
+        }
+      }
+      return {
+        goOp: match.row.goOp,
+        outputExt: formatToExt(match.row.outputFormat),
+        extraArgs: mergeUrlIntoExtraArgs(buildExtraArgs(match.row), urlState),
+      };
+    },
+    [slugDefault, detectedRow, urlState],
   );
 
   // SEAN-95 — Advanced disclosure. Mounted below the converter panel for
@@ -169,7 +268,9 @@ export function ConverterPanel({
     showAdvancedPanel && operation === 'convert' ? (
       <AdvancedPanel
         operation="convert"
-        ffmpegCommand={ffmpegCommand}
+        // SEAN-105: use the effective command so the displayed terminal line
+        // reflects the swapped-in row after an adaptive drop.
+        ffmpegCommand={effectiveFfmpegCommand}
         defaultCrf={advancedDefaults?.crf}
         defaultPreset={advancedDefaults?.preset}
         defaultBitrate={advancedDefaults?.bitrate}
@@ -208,13 +309,14 @@ export function ConverterPanel({
           />
         )}
         <DropZone
-          goOp={goOp}
-          outputExt={outputExt}
+          goOp={effectiveGoOp}
+          outputExt={effectiveOutputExt}
           accept={accept}
-          acceptLabel={acceptLabel}
+          acceptLabel={effectiveAcceptLabel}
           extraArgs={mergedExtraArgs}
           onJobComplete={setJob}
           initialFile={initialFile}
+          resolveArgsForFile={slugDefault ? resolveArgsForFile : undefined}
         />
         {advanced}
       </>

--- a/apps/ffmpeg-converter/web/src/components/DropZone.tsx
+++ b/apps/ffmpeg-converter/web/src/components/DropZone.tsx
@@ -29,15 +29,22 @@ export { submitConversion } from './submit-conversion';
 export interface DropZoneProps {
   /**
    * Backend op name as registered in the Go service (`ops.go::RegisterOps`).
-   * Comes from the matrix row's `goOp` field.
+   * Comes from the matrix row's `goOp` field. Used as the default when
+   * `resolveArgsForFile` is unset or returns a partial result.
    */
   goOp: string;
   /** Output format extension (no leading dot) — used to name the download. */
   outputExt: string;
   /**
-   * Comma-separated list of accepted MIME types or extensions for the
-   * `<input accept>` attribute (e.g. `.mov,.MOV,video/quicktime`).
-   * Optional — accepting everything still works, the backend will reject.
+   * Comma-separated list of accepted MIME types or extensions. Historically
+   * forwarded into the underlying `<input type="file">` `accept` attribute.
+   *
+   * SEAN-105: NO LONGER FORWARDED. Slug pages used to lock the picker to the
+   * row's input formats — drop a `.mov` on `/convert/mp4-to-gif` and the
+   * browser silently rejected it. The panel now detects the input type from
+   * the dropped file and adapts in place (see `ConverterPanel.slugDefault`),
+   * so we accept any file at the picker. The prop is kept for source-compat
+   * with existing call sites and may be removed in a follow-up.
    */
   accept?: string;
   /**
@@ -62,6 +69,23 @@ export interface DropZoneProps {
    * have to drop it a second time.
    */
   initialFile?: File;
+  /**
+   * SEAN-105: optional per-file argument resolver. Called synchronously
+   * before each `submitConversion`, with the file the user just dropped.
+   * Returning a partial set replaces the corresponding prop defaults for
+   * that single conversion (e.g. swapping `goOp` from `gif_from_video`
+   * driven by `mp4` to the same op driven by `mov` after detecting the
+   * actual input type).
+   *
+   * Keeping the resolver synchronous side-steps React's stale-state problem
+   * — the parent can't update `goOp` props in time for the imminent submit,
+   * but it CAN inspect the file and return the right args directly.
+   */
+  resolveArgsForFile?: (file: File) => {
+    goOp?: string;
+    outputExt?: string;
+    extraArgs?: Record<string, string>;
+  } | null;
 }
 
 type Status = 'idle' | 'uploading' | 'converting';
@@ -69,12 +93,13 @@ type Status = 'idle' | 'uploading' | 'converting';
 export function DropZone({
   goOp,
   outputExt,
-  accept,
+  accept: _acceptIgnored,
   acceptLabel,
   extraArgs,
   header,
   onJobComplete,
   initialFile,
+  resolveArgsForFile,
 }: DropZoneProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -98,11 +123,16 @@ export function DropZone({
 
       try {
         setStatus('converting');
+        // SEAN-105: synchronous per-file override hook. Lets ConverterPanel
+        // detect the dropped file's type and supply matching args before the
+        // submit fires (the React state update in the parent runs after this
+        // callback chain returns, so we can't rely on prop changes here).
+        const overrides = resolveArgsForFile?.(file) ?? null;
         const job = await submitConversion({
           file,
-          goOp,
-          outputExt,
-          extraArgs,
+          goOp: overrides?.goOp ?? goOp,
+          outputExt: overrides?.outputExt ?? outputExt,
+          extraArgs: overrides?.extraArgs ?? extraArgs,
           signal: controller.signal,
         });
         onJobComplete(job);
@@ -126,7 +156,7 @@ export function DropZone({
         }
       }
     },
-    [goOp, outputExt, extraArgs, onJobComplete],
+    [goOp, outputExt, extraArgs, onJobComplete, resolveArgsForFile],
   );
 
   const handleFile = (file: File) => {
@@ -231,11 +261,14 @@ export function DropZone({
             </div>
           </>
         )}
+        {/* SEAN-105: no `accept` attribute. The picker accepts every file;
+            the panel detects the input type and adapts its op + args in
+            place via `resolveArgsForFile`. Also no extension-based guard
+            in `handleDrop` — every dropped file flows through. */}
         <input
           ref={inputRef}
           type="file"
           hidden
-          accept={accept}
           onChange={(e) => {
             const file = e.target.files?.[0];
             if (file) handleFile(file);

--- a/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ToolPage.tsx
@@ -140,6 +140,17 @@ export function ToolPage({ row, page }: ToolPageProps) {
                   }
                 : undefined
             }
+            // SEAN-105 — slug-page seed for the adaptive panel. When the user
+            // drops a file whose detected input type maps to a different row
+            // (e.g. .mov on /convert/mp4-to-gif), the panel swaps the row and
+            // updates the URL via `history.replaceState` — no remount, no
+            // upload reset. The slug remains the URL-encoded "intent hint" the
+            // user landed on; first paint uses this row's metadata.
+            slugDefault={{
+              row,
+              inputFormat:
+                page?.inputFormat ?? row.inputFormats[0] ?? row.outputFormat,
+            }}
           />
         )}
       </section>

--- a/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
@@ -1,0 +1,112 @@
+/**
+ * SEAN-105 — adaptive-panel foundation: drop-mismatch detection.
+ *
+ * The panel itself is JSX (renders DropZone + ResultBlock + AdvancedPanel),
+ * so we can't test the swap UI from `node --test` without a JSDOM. What we
+ * CAN test is the load-bearing pure helper:
+ *
+ *   `adaptiveRowForFile(file, currentOperation, currentOutputFormat)`
+ *
+ * which encapsulates the entire decision: same row, swapped row preserving
+ * output, or fallback to PREFERRED_TARGET_BY_EXT. Every UI-driven scenario
+ * the panel implements reduces to one call into this helper.
+ *
+ * Test runner: `node --test` via ts-node (matches the rest of the suite).
+ * Run via: `yarn test:converter-panel`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { MATRIX_BY_SLUG } from '../../ops/matrix';
+import { adaptiveRowForFile } from '../route-for-file';
+
+describe('SEAN-105 ConverterPanel adaptive-panel — adaptiveRowForFile', () => {
+  it('keeps the current row when the dropped file matches the slug input', () => {
+    // Drop .mp4 on /convert/mp4-to-gif → no swap, stay on mp4-to-gif.
+    const match = adaptiveRowForFile({ name: 'screen.mp4' }, 'gif', 'gif');
+    assert.ok(match, 'mp4 on a gif page should resolve');
+    assert.equal(match.row.slug, 'mp4-to-gif');
+    assert.equal(match.row.operation, 'gif');
+    assert.equal(match.row.outputFormat, 'gif');
+  });
+
+  it('swaps to the matching same-output row when input differs (mov on mp4-to-gif)', () => {
+    // The load-bearing case from the AC: drop a .mov on /convert/mp4-to-gif
+    // and the panel should land on the mov-to-gif row, NOT the
+    // PREFERRED_TARGET_BY_EXT['mov']='mp4' default.
+    const match = adaptiveRowForFile({ name: 'iphone.mov' }, 'gif', 'gif');
+    assert.ok(match, 'mov on a gif page should resolve to a gif row');
+    assert.equal(match.row.slug, 'mov-to-gif');
+    assert.equal(match.row.operation, 'gif');
+    assert.equal(match.row.outputFormat, 'gif');
+    assert.equal(match.row.goOp, 'gif_from_video');
+  });
+
+  it('swaps to a same-output row across video formats (webm on mp4-to-gif)', () => {
+    const match = adaptiveRowForFile({ name: 'clip.webm' }, 'gif', 'gif');
+    assert.ok(match, 'webm on a gif page should resolve');
+    assert.equal(match.row.slug, 'webm-to-gif');
+    assert.equal(match.row.outputFormat, 'gif');
+  });
+
+  it('falls back to PREFERRED_TARGET_BY_EXT when no same-output row exists', () => {
+    // Drop a .png on /convert/mov-to-mp4 — there's no png-to-mp4 row, so the
+    // panel falls back to the preferred-target table. PNG's preferred target
+    // is webp → image-convert row. This validates the AC's "fall back to
+    // PREFERRED_TARGET_BY_EXT[ext]" clause.
+    const match = adaptiveRowForFile({ name: 'photo.png' }, 'convert', 'mp4');
+    assert.ok(
+      match,
+      'png on a video convert page should fall back to an image route',
+    );
+    // Output format necessarily changes — we lost the mp4 anchor.
+    assert.notEqual(
+      match.row.outputFormat,
+      'mp4',
+      'png cannot produce mp4 — output must change',
+    );
+    // png's preferred target is webp.
+    assert.equal(match.row.outputFormat, 'webp');
+  });
+
+  it('returns null for files with no extension (no swap, panel keeps current row)', () => {
+    const match = adaptiveRowForFile({ name: 'no-extension' }, 'gif', 'gif');
+    assert.equal(
+      match,
+      null,
+      'no extension → no detection → caller keeps current row',
+    );
+  });
+
+  it('returns null for genuinely unknown extensions', () => {
+    const match = adaptiveRowForFile({ name: 'mystery.xyz' }, 'gif', 'gif');
+    assert.equal(match, null);
+  });
+
+  it('preserves operation when an alternate input has a same-op row', () => {
+    // Drop a .mov on /convert/mp4-to-webm → there's a mov-to-webm row in the
+    // matrix; we must land on that, not on the gif row that also accepts mov.
+    const match = adaptiveRowForFile({ name: 'iphone.mov' }, 'convert', 'webm');
+    assert.ok(match, 'mov on /convert/mp4-to-webm should resolve');
+    assert.equal(match.row.operation, 'convert');
+    // Either a direct mov-to-webm row OR a multi-input video-to-webm row is
+    // acceptable — what matters is it stays a `convert` op landing on webm.
+    assert.equal(match.row.outputFormat, 'webm');
+  });
+
+  it('returned row must exist in the matrix (sanity check)', () => {
+    const match = adaptiveRowForFile({ name: 'iphone.mov' }, 'gif', 'gif');
+    assert.ok(match);
+    assert.ok(
+      MATRIX_BY_SLUG[match.row.slug],
+      `resolved slug ${match.row.slug} must exist in the matrix`,
+    );
+  });
+
+  it('extension comparison is case-insensitive (uppercase MOV resolves)', () => {
+    const match = adaptiveRowForFile({ name: 'iPhone.MOV' }, 'gif', 'gif');
+    assert.ok(match, 'uppercase extension should resolve like lowercase');
+    assert.equal(match.row.slug, 'mov-to-gif');
+  });
+});

--- a/apps/ffmpeg-converter/web/src/components/route-for-file.ts
+++ b/apps/ffmpeg-converter/web/src/components/route-for-file.ts
@@ -398,3 +398,65 @@ function formatExtName(format: Format): string {
       return format;
   }
 }
+
+/**
+ * SEAN-105 — adaptive panel: pick the matrix row that best matches a dropped
+ * file given the current page's operation + output format.
+ *
+ * Resolution order:
+ *   1. Same-operation row whose `inputFormats` includes the dropped input AND
+ *      whose `outputFormat` matches `currentOutputFormat`. Prefer the direct
+ *      `${input}-to-${output}` slug, then any multi-input fallback.
+ *   2. Otherwise fall back to `matrixRowForFile(file)` (which honours
+ *      `PREFERRED_TARGET_BY_EXT` per the existing routing table). The output
+ *      format necessarily changes here — the panel re-derives `goOp` /
+ *      `outputExt` / `extraArgs` from whatever row this lands on.
+ *   3. Returns `null` when the file's extension isn't routable at all (no
+ *      matching matrix row anywhere). Caller should keep the existing row
+ *      unchanged — friendly fallback messaging is a separate ticket.
+ *
+ * `currentOperation` is consulted as a soft hint: a `/convert/*` page should
+ * prefer a `convert` row, a `/gif/*` page a `gif` row, etc. Without it, the
+ * helper would happily swap a `/convert/mov-to-mp4` panel into a `/gif/mp4-to-gif`
+ * panel just because the input matched, which surprises the user.
+ */
+export function adaptiveRowForFile(
+  file: File | { name: string },
+  currentOperation: OperationRow['operation'],
+  currentOutputFormat: Format,
+): MatrixRowMatch | null {
+  const ext = extOf(file.name);
+  if (!ext) return null;
+
+  const inputFormat = (EXT_TO_FORMAT[ext] ?? ext) as Format;
+
+  // Step 1 — find a same-operation row that lands on the same output format.
+  // The direct `${input}-to-${output}` slug wins (Google ranks it; user landed
+  // on the equivalent slug); multi-input rows like `video-to-mp4` are the
+  // fallback within this step.
+  const directSlug = `${inputFormat}-to-${formatExtName(currentOutputFormat)}`;
+  const directRow = MATRIX_BY_SLUG[directSlug];
+  if (
+    directRow &&
+    directRow.operation === currentOperation &&
+    directRow.outputFormat === currentOutputFormat &&
+    directRow.inputFormats.includes(inputFormat) &&
+    routeExistsForSlug(directSlug)
+  ) {
+    return { row: directRow, inputFormat };
+  }
+
+  for (const row of MATRIX) {
+    if (row.operation !== currentOperation) continue;
+    if (row.outputFormat !== currentOutputFormat) continue;
+    if (!row.inputFormats.includes(inputFormat)) continue;
+    if (!MATRIX_BY_SLUG[row.slug]) continue;
+    if (!routeExistsForSlug(row.slug)) continue;
+    return { row, inputFormat };
+  }
+
+  // Step 2 — no row preserves the current output format for this input.
+  // Fall back to the preferred-target row (`PREFERRED_TARGET_BY_EXT`).
+  // Output format changes; the panel re-derives everything from the new row.
+  return matrixRowForFile(file);
+}


### PR DESCRIPTION
Closes #105

## Summary

- `<DropZone />` no longer forwards the `accept` attribute to the underlying `<input type="file">`. The picker now accepts every file. Adds optional `resolveArgsForFile(file)` callback so the parent can swap `goOp`/`outputExt`/`extraArgs` per-file synchronously, sidestepping React's stale-state-vs-imminent-submit race.
- `<ConverterPanel />` gets an optional `slugDefault: { row, inputFormat }` prop. Tracks a `detectedRow` state initialised from it; on file drop runs the new `adaptiveRowForFile` helper and swaps the row if the detected input maps to a different one. Re-derives `goOp`/`outputExt`/`extraArgs`/`ffmpegCommand`/`acceptLabel` from the swapped row and fires `history.replaceState` to update the URL slug. No `router.push`, no remount — the in-flight File survives.
- New `adaptiveRowForFile(file, currentOperation, currentOutputFormat)` helper in `route-for-file.ts` — resolution order: same-operation row preserving current output → multi-input same-operation fallback → `matrixRowForFile` fallback to `PREFERRED_TARGET_BY_EXT`.
- `<ToolPage />` passes `slugDefault` to `<ConverterPanel />` for every non-gif row.

## Test plan

- [x] `yarn test:converter-panel` — 9 new cases, all passing. Covers the AC scenario (.mov on /convert/mp4-to-gif → mov-to-gif), cross-operation fallback (.png on /convert/mov-to-mp4 → image-convert webp), case-insensitive extensions, no-extension files, unknown extensions.
- [x] Full `yarn test` suite — 12 suites, all passing.
- [x] `tsc --noEmit` clean on `apps/ffmpeg-converter/web`.
- [x] `biome check` clean on every touched file.
- [ ] Manual smoke: navigate to `/convert/mp4-to-gif`, drop a `.mov`, observe URL flips to `/convert/mov-to-gif` via `replaceState` (no spinner / no remount), GIF lands using `mov-to-gif` row metadata.

## Out of scope per ticket
- Chip-row reorganisation when output options change → next ticket (#106).
- Cross-category drop UX polish → ticket after that.
- Friendly fallback messaging when input has no matrix coverage → polish ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)