### PR TITLE
[SEAN-106] feat: chip row sourced from validOutputsFor(detectedInputType)

### DIFF
--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -34,6 +34,7 @@ import {
   formatToExt,
 } from './converter-row-args';
 import { type ConversionJob, DropZone } from './DropZone';
+import { OutputFormatChips } from './OutputFormatChips';
 import {
   deletePreset as deletePresetFromStorage,
   exportPresetsAsJson,
@@ -44,7 +45,7 @@ import {
   savePreset as savePresetToStorage,
 } from './preset-storage';
 import { ResultBlock } from './ResultBlock';
-import { adaptiveRowForFile } from './route-for-file';
+import { adaptiveRowForFile, extOf, outputsForExt } from './route-for-file';
 import { pathForSlug } from './route-registry';
 import {
   applyUrlState,
@@ -159,6 +160,22 @@ export function ConverterPanel({
     slugDefault?.row ?? null,
   );
 
+  // SEAN-106: detected input extension for the chip row. First-paint value is
+  // the slug's input format (per AC: "First-paint detected ext = slug's input
+  // format"). After a drop, the file's actual extension. Drives the chip-row
+  // option lookup via `outputsForExt(detectedInputExt)`.
+  const [detectedInputExt, setDetectedInputExt] = useState<string>(
+    slugDefault ? formatToExt(slugDefault.inputFormat) : '',
+  );
+
+  // SEAN-106: track the most-recently-dropped file so chip-pick remounts of
+  // the inner `<DropZone />` can re-fire the upload via `initialFile` instead
+  // of forcing the user to re-drop. Seeded from the parent's `initialFile`
+  // (homepage flow); updated on every fresh drop in the panel itself.
+  const [trackedFile, setTrackedFile] = useState<File | null>(
+    initialFile ?? null,
+  );
+
   // SEAN-93 — initial URL-state snapshot, read on mount. SSR-safe (returns
   // empty when `window` is undefined). Subscribes to `popstate` so the
   // browser back/forward buttons resync the panel; updates triggered by the
@@ -221,6 +238,13 @@ export function ConverterPanel({
   const resolveArgsForFile = useCallback(
     (file: File) => {
       if (!slugDefault) return null;
+      // SEAN-106: every drop refreshes the tracked file (chip clicks remount
+      // DropZone with this as `initialFile`) and the detected input ext (chip
+      // row sources its options from `outputsForExt(detectedInputExt)`).
+      setTrackedFile(file);
+      const droppedExt = extOf(file.name);
+      if (droppedExt) setDetectedInputExt(droppedExt);
+
       const currentRow = detectedRow ?? slugDefault.row;
       const match = adaptiveRowForFile(
         file,
@@ -255,6 +279,40 @@ export function ConverterPanel({
       };
     },
     [slugDefault, detectedRow, urlState],
+  );
+
+  // SEAN-106: chip-pick handler. Looks up the row matching the detected input
+  // + picked output via `outputsForExt`, swaps `detectedRow`, updates the URL
+  // via `history.replaceState`, and re-keys the inner `<DropZone />` so the
+  // in-flight upload (if any) is aborted via the AbortController cleanup and
+  // re-fired with the new row's args via `initialFile={trackedFile}`.
+  const handleChipPick = useCallback(
+    (nextFormat: Format) => {
+      if (!slugDefault) return;
+      const currentRow = detectedRow ?? slugDefault.row;
+      if (nextFormat === currentRow.outputFormat) return;
+      const options = outputsForExt(detectedInputExt);
+      const next = options.find((o) => o.format === nextFormat);
+      if (!next) return;
+      setDetectedRow(next.row);
+      // SEAN-106: clear any completed job so a chip pick from the result
+      // block reverts to the DropZone — which then auto-fires via
+      // `initialFile={trackedFile}` on the freshly-keyed mount. Mirrors the
+      // homepage flow where re-picking on the result block re-fires the
+      // conversion with the new row's args.
+      setJob(null);
+      if (typeof window !== 'undefined') {
+        const newPath = pathForSlug(next.row.slug);
+        if (newPath && newPath !== window.location.pathname) {
+          window.history.replaceState(
+            null,
+            '',
+            newPath + window.location.search,
+          );
+        }
+      }
+    },
+    [slugDefault, detectedRow, detectedInputExt],
   );
 
   // SEAN-95 — Advanced disclosure. Mounted below the converter panel for
@@ -294,6 +352,35 @@ export function ConverterPanel({
     };
   }, [operation]);
 
+  // SEAN-106: chip row mounts above the DropZone on slug pages only. The
+  // homepage flow already wraps `<ConverterPanel />` with its own chip row
+  // inside `<HeroDrop />`'s `<RunningPanel />`, so we'd double-render
+  // otherwise. Active chip = the panel's current effective output format
+  // (which falls back to `PREFERRED_TARGET_BY_EXT[ext]` when the URL's hinted
+  // output isn't reachable from the detected input — see SEAN-105 / SEAN-103
+  // decision records).
+  const slugChipRow = slugDefault ? (
+    <OutputFormatChips
+      detectedInputExt={detectedInputExt}
+      activeFormat={effectiveOutputExt}
+      onPick={handleChipPick}
+    />
+  ) : null;
+
+  // SEAN-106: re-key the inner `<DropZone />` on the effective row's slug.
+  // Picking a different output chip swaps `detectedRow`, which changes the
+  // key, which unmounts the old DropZone (firing AbortController cleanup ⇒
+  // in-flight upload aborts) and mounts a fresh one with `initialFile=
+  // trackedFile`, auto-re-firing the upload with the new row's args.
+  const dropZoneKey = slugDefault
+    ? (detectedRow ?? slugDefault.row).slug
+    : undefined;
+  // For slug pages, the parent `<HeroDrop />` doesn't supply `initialFile` —
+  // but after the first drop, the panel itself tracks the file so chip-pick
+  // remounts can re-fire. Homepage flow keeps using its own `initialFile`
+  // (passed as a prop and seeded into `trackedFile` on mount).
+  const effectiveInitialFile = trackedFile ?? initialFile;
+
   if (!job) {
     return (
       <>
@@ -308,14 +395,16 @@ export function ConverterPanel({
             }}
           />
         )}
+        {slugChipRow}
         <DropZone
+          key={dropZoneKey}
           goOp={effectiveGoOp}
           outputExt={effectiveOutputExt}
           accept={accept}
           acceptLabel={effectiveAcceptLabel}
           extraArgs={mergedExtraArgs}
           onJobComplete={setJob}
-          initialFile={initialFile}
+          initialFile={effectiveInitialFile}
           resolveArgsForFile={slugDefault ? resolveArgsForFile : undefined}
         />
         {advanced}
@@ -324,6 +413,7 @@ export function ConverterPanel({
   }
   return (
     <>
+      {slugChipRow}
       <ResultBlock
         job={job}
         ffmpegCommand={displayedCommand}

--- a/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
+++ b/apps/ffmpeg-converter/web/src/components/HeroDrop.tsx
@@ -37,6 +37,7 @@ import {
   findReverse,
   formatToExt,
 } from './converter-row-args';
+import { OutputFormatChips } from './OutputFormatChips';
 import {
   extOf,
   friendlyDropError,
@@ -223,72 +224,19 @@ function RunningPanel({
     });
   };
 
-  // Only render the chip row when there's at least one alternative format
-  // (i.e. options.length >= 2). Single-output inputs would just see one chip
-  // showing what's already running — adds noise, removes nothing.
-  const showChips = options.length >= 2;
-
   return (
     <div className="w-full">
-      {showChips && (
-        <div
-          className={[
-            'mb-4 flex flex-col items-center gap-3',
-            'rounded-2xl border border-gray-800 bg-gray-900/40',
-            'px-4 py-3 sm:flex-row sm:justify-between',
-          ].join(' ')}
-        >
-          <div className="flex items-center gap-2 text-sm text-gray-300">
-            <span aria-hidden>{'\u{1F4C4}'}</span>
-            <span className="max-w-[16rem] truncate font-medium">
-              {file.name}
-            </span>
-            <span className="text-gray-500">→</span>
-            <span className="font-medium text-gray-100">.{outputExt}</span>
-          </div>
-          <ul
-            aria-label="Change output format"
-            className="flex flex-wrap items-center justify-center gap-2"
-          >
-            <li className="text-xs text-gray-500">change format:</li>
-            {options.map((option) => {
-              const active = option.format === row.outputFormat;
-              return (
-                <li key={option.format}>
-                  <button
-                    type="button"
-                    aria-pressed={active}
-                    onClick={() => handlePick(option.format)}
-                    className={[
-                      'inline-flex items-center rounded-full',
-                      'border px-3 py-1 text-xs font-medium transition-colors',
-                      active
-                        ? 'border-indigo-400 bg-indigo-500/20 text-white'
-                        : 'border-gray-700 bg-gray-900/60 text-gray-200 hover:border-indigo-500 hover:bg-indigo-500/10',
-                    ].join(' ')}
-                  >
-                    {option.label}
-                  </button>
-                </li>
-              );
-            })}
-            <li>
-              <button
-                type="button"
-                onClick={onCancel}
-                className={[
-                  'inline-flex items-center rounded-full',
-                  'border border-gray-700 bg-transparent px-3 py-1',
-                  'text-xs text-gray-400',
-                  'transition-colors hover:border-gray-600 hover:text-gray-300',
-                ].join(' ')}
-              >
-                Cancel
-              </button>
-            </li>
-          </ul>
-        </div>
-      )}
+      {/* SEAN-106: chip row extracted into <OutputFormatChips />. Hides itself
+          when outputsForExt(ext).length < 2. The homepage flow passes the
+          dropped file's name + a Cancel button (returns to empty hero); slug
+          pages call the same component without those props. */}
+      <OutputFormatChips
+        detectedInputExt={ext}
+        activeFormat={row.outputFormat}
+        onPick={handlePick}
+        fileName={file.name}
+        onCancel={onCancel}
+      />
       <ConverterPanel
         // SEAN-81: keying on the row slug forces a fresh mount when the user
         // re-picks the output format. The unmount aborts the in-flight

--- a/apps/ffmpeg-converter/web/src/components/OutputFormatChips.tsx
+++ b/apps/ffmpeg-converter/web/src/components/OutputFormatChips.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+// SEAN-106 — reusable output-format chip row.
+//
+// Extracted from `<HeroDrop />`'s `<RunningPanel />` (introduced in #79 and
+// hardened in #81 for the auto-fire / abort-on-pick flow). The same chip row
+// now also mounts above `<ConverterPanel />` on every non-gif slug page so
+// the user can swap the output format mid-conversion without re-dropping the
+// file. See `apps/ffmpeg-converter/docs/STRATEGY.md` § "Adaptive panel —
+// input-type detection over URL-as-constraint".
+//
+// Sourcing principle (locked in SEAN-103 + SEAN-105): the chip row's options
+// come from `outputsForExt(detectedInputExt)` — never hardcoded per-slug. The
+// caller passes the *currently-detected* input ext (which is the slug's input
+// on first paint, the dropped file's ext after a drop) and the active output
+// format; this component handles rendering, hover state, and the click-to-pick
+// callback.
+//
+// Hidden when `outputsForExt(ext).length < 2` — a one-output input (rare in
+// practice) would render a single chip showing what's already running.
+
+import { useMemo } from 'react';
+import type { Format } from '@/ops/types';
+import { outputsForExt } from './route-for-file';
+
+export interface OutputFormatChipsProps {
+  /**
+   * The detected input extension (no leading dot). Drives the option set via
+   * `outputsForExt(detectedInputExt)`. On first paint of a slug page this is
+   * the slug's declared input; after a drop it's the dropped file's ext.
+   */
+  detectedInputExt: string;
+  /**
+   * Currently-active output format (the one the panel is converting to).
+   * Matched against `option.format` to render the active chip's pressed state.
+   */
+  activeFormat: Format | string;
+  /**
+   * Called when the user picks a different output format. The caller is
+   * responsible for swapping the panel's row + aborting any in-flight upload
+   * (typically by re-keying the inner `<DropZone />` so its AbortController
+   * cleanup fires on unmount).
+   *
+   * Picks of the already-active format are suppressed inside this component
+   * — the callback only fires for genuine swaps.
+   */
+  onPick: (nextFormat: Format) => void;
+  /**
+   * Optional file name to display in the chip header — used by the homepage
+   * `<HeroDrop />` flow to surface "{file.name} → .{ext}" alongside the chip
+   * row. Slug pages don't render this header (the file may not be uploaded
+   * yet on first paint and the surrounding shell already names the format).
+   */
+  fileName?: string;
+  /**
+   * Optional cancel button — used by the homepage flow to return to the empty
+   * hero drop zone. Slug pages don't render Cancel (there's no empty state to
+   * return to; "Try another file" on the result block is the equivalent).
+   */
+  onCancel?: () => void;
+}
+
+/**
+ * SEAN-106 — output-format chip row. Renders one chip per `outputsForExt`
+ * option; the active chip is `aria-pressed`. Returns `null` when fewer than
+ * two options would render (per the AC: "When `outputsForExt(ext).length < 2`
+ * chip row hides itself").
+ */
+export function OutputFormatChips({
+  detectedInputExt,
+  activeFormat,
+  onPick,
+  fileName,
+  onCancel,
+}: OutputFormatChipsProps) {
+  const options = useMemo(
+    () => outputsForExt(detectedInputExt),
+    [detectedInputExt],
+  );
+
+  // Per AC: hide entirely when there's nothing to choose between.
+  if (options.length < 2) return null;
+
+  const handlePick = (nextFormat: string) => {
+    if (nextFormat === activeFormat) return;
+    onPick(nextFormat as Format);
+  };
+
+  return (
+    <div
+      className={[
+        'mb-4 flex flex-col items-center gap-3',
+        'rounded-2xl border border-gray-800 bg-gray-900/40',
+        'px-4 py-3 sm:flex-row sm:justify-between',
+      ].join(' ')}
+    >
+      {fileName ? (
+        <div className="flex items-center gap-2 text-sm text-gray-300">
+          <span aria-hidden>{'\u{1F4C4}'}</span>
+          <span className="max-w-[16rem] truncate font-medium">{fileName}</span>
+          <span className="text-gray-500">→</span>
+          <span className="font-medium text-gray-100">.{activeFormat}</span>
+        </div>
+      ) : null}
+      <ul
+        aria-label="Change output format"
+        className="flex flex-wrap items-center justify-center gap-2"
+      >
+        <li className="text-xs text-gray-500">change format:</li>
+        {options.map((option) => {
+          const active = option.format === activeFormat;
+          return (
+            <li key={option.format}>
+              <button
+                type="button"
+                aria-pressed={active}
+                onClick={() => handlePick(option.format)}
+                className={[
+                  'inline-flex items-center rounded-full',
+                  'border px-3 py-1 text-xs font-medium transition-colors',
+                  active
+                    ? 'border-indigo-400 bg-indigo-500/20 text-white'
+                    : 'border-gray-700 bg-gray-900/60 text-gray-200 hover:border-indigo-500 hover:bg-indigo-500/10',
+                ].join(' ')}
+              >
+                {option.label}
+              </button>
+            </li>
+          );
+        })}
+        {onCancel ? (
+          <li>
+            <button
+              type="button"
+              onClick={onCancel}
+              className={[
+                'inline-flex items-center rounded-full',
+                'border border-gray-700 bg-transparent px-3 py-1',
+                'text-xs text-gray-400',
+                'transition-colors hover:border-gray-600 hover:text-gray-300',
+              ].join(' ')}
+            >
+              Cancel
+            </button>
+          </li>
+        ) : null}
+      </ul>
+    </div>
+  );
+}

--- a/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
@@ -19,7 +19,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 
 import { MATRIX_BY_SLUG } from '../../ops/matrix';
-import { adaptiveRowForFile } from '../route-for-file';
+import { adaptiveRowForFile, outputsForExt } from '../route-for-file';
 
 describe('SEAN-105 ConverterPanel adaptive-panel — adaptiveRowForFile', () => {
   it('keeps the current row when the dropped file matches the slug input', () => {
@@ -108,5 +108,76 @@ describe('SEAN-105 ConverterPanel adaptive-panel — adaptiveRowForFile', () => 
     const match = adaptiveRowForFile({ name: 'iPhone.MOV' }, 'gif', 'gif');
     assert.ok(match, 'uppercase extension should resolve like lowercase');
     assert.equal(match.row.slug, 'mov-to-gif');
+  });
+});
+
+describe('SEAN-106 OutputFormatChips on slug pages', () => {
+  it('drop .webm on /convert/mov-to-mp4 → webm-output options, .mp4 active', () => {
+    // The load-bearing AC scenario: user lands on /convert/mov-to-mp4 (a
+    // mov→mp4 convert row), drops a .webm. The panel re-detects the input
+    // ext as `webm`; the chip row's options come from outputsForExt('webm');
+    // active chip = the panel's current effective output, which after
+    // adaptiveRowForFile resolves should land on mp4 (webm's preferred
+    // target per PREFERRED_TARGET_BY_EXT, since there's no webm-to-mov).
+    const match = adaptiveRowForFile({ name: 'clip.webm' }, 'convert', 'mp4');
+    assert.ok(match, 'webm on a convert page should resolve');
+    // webm has no webm-to-mp4 same-output preservation step (the source
+    // page was mov-to-mp4, mp4 is mov's preferred target). For webm the
+    // matrix exposes a webm-to-mp4 row directly, so the same-output match
+    // should land on it.
+    assert.equal(
+      match.row.outputFormat,
+      'mp4',
+      'webm on /convert/mov-to-mp4 should preserve mp4 as output',
+    );
+
+    // Chip-row options for webm input must include mp4 (active) plus other
+    // outputs the user can pick.
+    const options = outputsForExt('webm');
+    const formats = new Set(options.map((o) => o.format));
+    assert.ok(formats.has('mp4'), 'webm chip row must offer mp4');
+    assert.ok(
+      options.length >= 2,
+      'webm chip row must show at least 2 chips so the row is visible',
+    );
+    // The active chip is the resolved output — must exist in the options.
+    assert.ok(
+      formats.has(match.row.outputFormat),
+      'effective output format must appear as a chip option',
+    );
+  });
+
+  it('chip row hides itself when outputsForExt(ext).length < 2', () => {
+    // Per AC: "When `outputsForExt(ext).length < 2` chip row hides itself."
+    // We model this with the empty-extension case (no input → no options).
+    const empty = outputsForExt('');
+    assert.equal(empty.length, 0, 'empty ext returns no options');
+    const unknown = outputsForExt('xyz-not-real');
+    assert.equal(unknown.length, 0, 'unknown ext returns no options');
+  });
+
+  it('falls back to PREFERRED_TARGET_BY_EXT when URL output is unreachable', () => {
+    // AC: "When detected input doesn't support URL's hinted output (e.g.
+    // `.mov` on `/convert/mp4-to-webm` with no `mov-to-webm` row), chip
+    // row's active state falls back to `PREFERRED_TARGET_BY_EXT[ext]`."
+    //
+    // The matrix today *does* have `mov-to-webm` — so we synthesise the
+    // condition with png on a video-output page where no png-to-mp4 row
+    // exists. PNG's preferred target is webp; that's what the chip row
+    // active state should be.
+    const match = adaptiveRowForFile({ name: 'photo.png' }, 'convert', 'mp4');
+    assert.ok(match, 'png on a convert page must fall back to a routable row');
+    assert.equal(
+      match.row.outputFormat,
+      'webp',
+      "png's preferred target is webp; active chip falls back to it",
+    );
+    // The chip row options for png must include the resolved output.
+    const options = outputsForExt('png');
+    const formats = new Set(options.map((o) => o.format));
+    assert.ok(
+      formats.has('webp'),
+      'png chip row must include the fallback output',
+    );
   });
 });


### PR DESCRIPTION
Closes #106

## Summary
- Extracts the format-picker chip row currently embedded in `<HeroDrop />`'s `<RunningPanel />` (introduced in #79, hardened in #81) into a reusable `<OutputFormatChips />` component.
- Lifts the chip row onto every non-gif slug page above `<ConverterPanel />`. Options always come from `outputsForExt(detectedInputExt)` — never hardcoded per-slug. First-paint detected ext is the slug's input format; after a drop the file's actual ext.
- Active chip = panel's current effective output. When the URL's hinted output isn't reachable from the detected input (e.g. dropping a `.png` on a video page), the active chip falls back to `PREFERRED_TARGET_BY_EXT[ext]` via the existing `adaptiveRowForFile` -> `matrixRowForFile` chain.
- Chip clicks swap `detectedRow`, update the URL via `history.replaceState`, and re-key the inner `<DropZone />`. The remount fires the AbortController cleanup (cancelling any in-flight upload) and auto-re-fires the new row's conversion via `initialFile={trackedFile}` — file survives end-to-end.
- Gif slug pages keep `<GifPresetPanel />` untouched: `GifPresetPanel` doesn't pass `slugDefault`, so `<ConverterPanel />` skips rendering the chip row alongside gif preset chips.
- Hides itself when `outputsForExt(ext).length < 2` (single-output inputs would just render one chip showing what's already running — adds noise, removes nothing).

## Test plan
- [x] `yarn tsc --noEmit` clean in `apps/ffmpeg-converter/web`.
- [x] `yarn check` introduces zero new lint diagnostics (baseline 7 errors unchanged).
- [x] `yarn test:converter-panel` passes — three new SEAN-106 tests:
  - Drop `.webm` on `/convert/mov-to-mp4` -> webm-output options surface, `.mp4` is active.
  - Chip row hides when `outputsForExt(ext).length < 2` (empty / unknown ext returns no options).
  - Drop `.png` on `/convert/mov-to-mp4` -> active chip falls back to `webp` (PNG's preferred target) since no `png-to-mp4` row exists.
- [x] `yarn test:hero-drop` (homepage chip row) still passes — extraction is behaviour-preserving.
- [ ] Manual smoke (post-merge): land on `/convert/mov-to-mp4`, drop a `.webm`, verify chip row swaps to webm options with `.mp4` active and the URL rewrites to `/convert/webm-to-mp4`.