### PR TITLE
[SEAN-107] feat: cross-category drop adapts panel without losing the file

### DIFF
--- a/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
+++ b/apps/ffmpeg-converter/web/src/components/ConverterPanel.tsx
@@ -196,26 +196,26 @@ export function ConverterPanel({
   // browser back/forward buttons resync the panel; updates triggered by the
   // panel itself go through `applyUrlState` (replaceState) which doesn't
   // fire popstate, so there's no feedback loop.
+  //
+  // SEAN-107: re-parse on `effectiveOperation` change too — when a cross-
+  // category drop swaps the panel from `convert` to `image-convert`, the
+  // whitelist switches and any params from the previous slug that aren't
+  // in the new whitelist are silently dropped. See decision record SEAN-103
+  // case 3 + the URL-state bullet ("URL params from previous whitelist not
+  // in new whitelist are silently dropped").
   const [urlState, setUrlState] = useState<UrlState>({});
-
-  useEffect(() => {
-    if (typeof window === 'undefined' || !operation) return;
-    const sync = () => {
-      const params = new URLSearchParams(window.location.search);
-      setUrlState(parseUrlState(params, operation));
-    };
-    sync();
-    window.addEventListener('popstate', sync);
-    return () => {
-      window.removeEventListener('popstate', sync);
-    };
-  }, [operation]);
 
   // SEAN-105: when the dropped file's detected row differs from the slug
   // default, all the row-derived knobs (goOp, outputExt, extraArgs, ffmpeg
   // command, accept label) re-derive from the detected row instead of the
   // props. The slug default IS the detected row on first paint, so before any
   // drop the effective values match the props 1:1.
+  //
+  // SEAN-107: `effectiveOperation` joins the family. A cross-category drop
+  // (`.png` on `/convert/mp4-to-gif` ⇒ swap to an `image-convert` row) flips
+  // the operation to the detected row's. The URL-state whitelist, the
+  // saved-presets bar, and the Advanced disclosure all read from this
+  // value rather than the slug's hard-coded `operation` prop.
   const detectedSwapped =
     detectedRow !== null && detectedRow.slug !== slugDefault?.row.slug;
   const effectiveGoOp = detectedSwapped ? detectedRow.goOp : goOp;
@@ -231,6 +231,21 @@ export function ConverterPanel({
   const effectiveAcceptLabel = detectedSwapped
     ? buildAcceptLabel(detectedRow)
     : acceptLabel;
+  const effectiveOperation: Operation | undefined =
+    detectedRow?.operation ?? operation;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !effectiveOperation) return;
+    const sync = () => {
+      const params = new URLSearchParams(window.location.search);
+      setUrlState(parseUrlState(params, effectiveOperation));
+    };
+    sync();
+    window.addEventListener('popstate', sync);
+    return () => {
+      window.removeEventListener('popstate', sync);
+    };
+  }, [effectiveOperation]);
 
   // Merge URL state into the (possibly-swapped) row's preset-derived extraArgs
   // (URL wins) and substitute the same values into the displayed ffmpeg
@@ -302,10 +317,30 @@ export function ConverterPanel({
           );
         }
       }
+      // SEAN-107: when a cross-category drop flips the operation, re-parse
+      // the URL through the new whitelist so the in-flight POST doesn't ship
+      // params from the old slug's schema (e.g. `fps=24` hanging off
+      // `/convert/mp4-to-gif?fps=24` is meaningless on the new
+      // `image-convert` row). Same effect the post-swap useEffect would
+      // produce, just executed synchronously here so the immediate
+      // submission uses the cleaned-up args. Same-operation swaps short-
+      // circuit to the existing `urlState` because the whitelist hasn't
+      // changed.
+      const swappedUrlState =
+        match.row.operation !== currentRow.operation &&
+        typeof window !== 'undefined'
+          ? parseUrlState(
+              new URLSearchParams(window.location.search),
+              match.row.operation,
+            )
+          : urlState;
       return {
         goOp: match.row.goOp,
         outputExt: formatToExt(match.row.outputFormat),
-        extraArgs: mergeUrlIntoExtraArgs(buildExtraArgs(match.row), urlState),
+        extraArgs: mergeUrlIntoExtraArgs(
+          buildExtraArgs(match.row),
+          swappedUrlState,
+        ),
       };
     },
     [slugDefault, detectedRow, urlState],
@@ -352,8 +387,16 @@ export function ConverterPanel({
   // BUT: replaceState doesn't fire popstate, so we expose a state-setter so
   // AdvancedPanel can also push the change directly into urlState here. We
   // wrap that into a child-callback to keep the URL ↔ React loop tight.
+  //
+  // SEAN-107: appearance gates on `effectiveOperation`, not the slug's prop.
+  // A `.png` dropped on `/convert/mp4-to-gif` flips the panel to
+  // `image-convert` — the Advanced disclosure must hide. A `.mov` dropped on
+  // `/gif/png-to-jpg` (hypothetical) would flip the panel to `convert` —
+  // the disclosure must appear if `showAdvancedPanel` is on. The slug-page
+  // shell decides whether the disclosure is *eligible* (`showAdvancedPanel`),
+  // the detected operation decides whether it's currently *applicable*.
   const advanced =
-    showAdvancedPanel && operation === 'convert' ? (
+    showAdvancedPanel && effectiveOperation === 'convert' ? (
       <AdvancedPanel
         operation="convert"
         // SEAN-105: use the effective command so the displayed terminal line
@@ -370,17 +413,21 @@ export function ConverterPanel({
 
   // Re-sync urlState after Advanced panel writes — replaceState doesn't fire
   // popstate, so we listen on a custom event the panel emits when it writes.
+  // SEAN-107: same `effectiveOperation` swap as the parse-on-mount effect —
+  // a cross-category drop re-binds the listener to the new operation's
+  // whitelist so an Advanced-panel write under the new operation is parsed
+  // through the right schema.
   useEffect(() => {
-    if (typeof window === 'undefined' || !operation) return;
+    if (typeof window === 'undefined' || !effectiveOperation) return;
     const onChange = () => {
       const params = new URLSearchParams(window.location.search);
-      setUrlState(parseUrlState(params, operation));
+      setUrlState(parseUrlState(params, effectiveOperation));
     };
     window.addEventListener('ffmpeg-converter:url-state', onChange);
     return () => {
       window.removeEventListener('ffmpeg-converter:url-state', onChange);
     };
-  }, [operation]);
+  }, [effectiveOperation]);
 
   // SEAN-106: chip row mounts above the DropZone on slug pages only. The
   // homepage flow already wraps `<ConverterPanel />` with its own chip row
@@ -451,13 +498,19 @@ export function ConverterPanel({
     }
     return (
       <>
-        {operation && (
+        {effectiveOperation && (
+          // SEAN-107: presets are per-operation. After a cross-category drop
+          // the bar reads the *current* operation, which has flipped — so a
+          // user's saved gif presets don't pollute the chip row when they
+          // drop a png on a gif page (and vice versa). Falls out of the
+          // operation-switch model with no extra wiring; see decision record
+          // SEAN-103 § "saved presets" bullet.
           <SavedPresetsBar
-            operation={operation}
+            operation={effectiveOperation}
             currentArgs={urlState}
             onApply={(preset) => {
               if (typeof window === 'undefined') return;
-              applyUrlState(preset.args, operation);
+              applyUrlState(preset.args, effectiveOperation);
               setUrlState(preset.args);
             }}
           />

--- a/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
+++ b/apps/ffmpeg-converter/web/src/components/__tests__/ConverterPanel.test.ts
@@ -25,6 +25,8 @@ import {
   matrixRowForFile,
   outputsForExt,
 } from '../route-for-file';
+import { pathForSlug } from '../route-registry';
+import { parseUrlState, URL_PARAM_WHITELIST } from '../url-state';
 
 describe('SEAN-105 ConverterPanel adaptive-panel — adaptiveRowForFile', () => {
   it('keeps the current row when the dropped file matches the slug input', () => {
@@ -260,5 +262,184 @@ describe('SEAN-108 ConverterPanel friendly-fallback — no matrix coverage', () 
     // second message string must trip an explicit grep for this test.
     assert.equal(typeof homepageMsg, 'string');
     assert.ok(homepageMsg.length > 0);
+  });
+});
+
+/**
+ * SEAN-107 — cross-category drop adapts the panel without losing the file.
+ *
+ * Same testability constraint as SEAN-105: ConverterPanel renders JSX, so we
+ * test the load-bearing decision via the pure helpers it composes. The
+ * panel's behaviour for `.png` dropped on `/convert/mp4-to-gif`:
+ *
+ *   1. `adaptiveRowForFile(file, currentRow.operation, currentRow.outputFormat)`
+ *      finds no same-output row for png on a gif page → falls through to
+ *      `matrixRowForFile(file)` → resolves to the image-convert/png-to-webp
+ *      row.
+ *   2. The panel sets `detectedRow = match.row` → `effectiveOperation` flips
+ *      to the new row's operation (`'image-convert'`).
+ *   3. URL update via `pathForSlug(match.row.slug)` →
+ *      `/convert/png-to-webp` (image-convert is aliased onto /convert).
+ *   4. URL-state useEffect re-parses with the new operation; any params from
+ *      the previous slug not in the new whitelist are silently dropped.
+ *
+ * Step (3) and (4) are pure-function assertions — no JSX render needed.
+ */
+describe('SEAN-107 ConverterPanel cross-category drop — operation switch', () => {
+  it('PNG dropped on /convert/mp4-to-gif resolves to a different operation', () => {
+    // The headline AC scenario. The slug page is `gif`/`gif`; the dropped
+    // file is `.png`. The resolved row must come from a different operation
+    // (image-convert, not gif) — that's what makes it a cross-category swap.
+    const match = adaptiveRowForFile({ name: 'photo.png' }, 'gif', 'gif');
+    assert.ok(match, 'png on a gif page must resolve via cross-category');
+    assert.notEqual(
+      match.row.operation,
+      'gif',
+      'cross-category swap MUST flip the operation away from gif',
+    );
+    assert.equal(
+      match.row.operation,
+      'image-convert',
+      'png belongs on image-convert, not gif/convert',
+    );
+    assert.equal(
+      match.row.outputFormat,
+      'webp',
+      'png prefers webp per PREFERRED_TARGET_BY_EXT',
+    );
+    // Today the matrix has a multi-input `image-to-webp` row (covering
+    // jpg/png/heic/avif → webp), not a direct `png-to-webp` slug. The AC's
+    // example URL `/convert/png-to-webp` is illustrative — the real slug
+    // the panel lands on is whichever multi-input row covers png. If a
+    // future commit splits this into a per-input row the slug here will
+    // change; the test pins the OPERATION, not the exact slug.
+    assert.ok(
+      MATRIX_BY_SLUG[match.row.slug],
+      `cross-category swap landed on slug ${match.row.slug} which must exist in the matrix`,
+    );
+  });
+
+  it('cross-category resolved row has a real route via pathForSlug', () => {
+    // The panel calls `pathForSlug(match.row.slug)` to update the URL via
+    // history.replaceState. That call must return a non-null path so the
+    // URL bar reflects the now-correct slug. The exact path depends on
+    // which row the matrix exposes for png → webp today (image-to-webp)
+    // — but it MUST live under /convert/ because image-convert aliases
+    // there per route-registry.
+    const match = adaptiveRowForFile({ name: 'photo.png' }, 'gif', 'gif');
+    assert.ok(match);
+    const newPath = pathForSlug(match.row.slug);
+    assert.ok(newPath, 'cross-category swap must produce a non-null URL path');
+    assert.ok(
+      newPath.startsWith('/convert/'),
+      `image-convert aliases to /convert/, got: ${newPath}`,
+    );
+    // And critically, it's not the slug we landed on — replaceState only
+    // fires when the new path differs from the current location. The
+    // mp4-to-gif slug lives at /gif/mp4-to-gif (operation `gif`), not
+    // /convert/mp4-to-gif — but either way the new path differs.
+    assert.notEqual(newPath, pathForSlug('mp4-to-gif'));
+  });
+
+  it('flipping from gif to image-convert drops gif-only URL params', () => {
+    // The AC: "URL-state params from previous whitelist not in new whitelist
+    // are silently dropped." Concretely, a shared link
+    // `/convert/mp4-to-gif?fps=24&max_colors=128` followed by a png drop
+    // should re-parse the URL through the image-convert whitelist, which
+    // dumps `fps` and `max_colors` (gif-only) on the floor.
+    const params = new URLSearchParams('?fps=24&max_colors=128&width=320');
+    const beforeSwap = parseUrlState(params, 'gif');
+    assert.equal(beforeSwap.fps, '24', 'fps survives on gif whitelist');
+    assert.equal(
+      beforeSwap.max_colors,
+      '128',
+      'max_colors survives on gif whitelist',
+    );
+
+    const afterSwap = parseUrlState(params, 'image-convert');
+    assert.equal(
+      afterSwap.fps,
+      undefined,
+      'fps is NOT in image-convert whitelist → dropped',
+    );
+    assert.equal(
+      afterSwap.max_colors,
+      undefined,
+      'max_colors is NOT in image-convert whitelist → dropped',
+    );
+    // image-convert keeps `width` (it's in both whitelists), so a shared
+    // link with width=320 still applies after a png drop. Verifies the
+    // "silently dropped" behaviour is per-param, not all-or-nothing.
+    assert.equal(
+      afterSwap.width,
+      '320',
+      'width IS in image-convert whitelist → preserved',
+    );
+  });
+
+  it('image-convert whitelist excludes the convert/gif advanced knobs', () => {
+    // Structural pin: the AC for SEAN-107 depends on the whitelists not
+    // overlapping for the advanced knobs (fps, max_colors, dither, crf,
+    // bitrate, codec). If a future commit accidentally adds `fps` to the
+    // image-convert whitelist this test will fail loudly so we know the
+    // "silently dropped" behaviour for that param has changed.
+    const imageWhitelist = URL_PARAM_WHITELIST['image-convert'];
+    assert.ok(
+      !imageWhitelist.includes('fps'),
+      'fps must stay gif/extract-frames-only',
+    );
+    assert.ok(
+      !imageWhitelist.includes('max_colors'),
+      'max_colors must stay gif-only',
+    );
+    assert.ok(!imageWhitelist.includes('crf'), 'crf must stay convert-only');
+    assert.ok(
+      !imageWhitelist.includes('codec'),
+      'codec must stay convert-only',
+    );
+  });
+
+  it('cross-category swap landing on image-convert hides Advanced disclosure', () => {
+    // The Advanced disclosure renders only when the *effective* operation is
+    // `convert`. After a png drop on a gif page the effective operation is
+    // `image-convert` → the Advanced panel must not render. We assert the
+    // structural property the panel uses to make that decision: the
+    // resolved row's operation is NOT 'convert'.
+    const match = adaptiveRowForFile({ name: 'photo.png' }, 'gif', 'gif');
+    assert.ok(match);
+    assert.notEqual(
+      match.row.operation,
+      'convert',
+      'png cross-category swap must not land on a convert row → Advanced hidden',
+    );
+  });
+
+  it('mp4 dropped on a gif page is NOT cross-category (same operation kept)', () => {
+    // Negative anchor: the cross-category branch must only trigger when the
+    // operation actually differs. Dropping the slug's declared input on its
+    // own page is the dominant case and must not flip operations.
+    const match = adaptiveRowForFile({ name: 'video.mp4' }, 'gif', 'gif');
+    assert.ok(match);
+    assert.equal(
+      match.row.operation,
+      'gif',
+      'same-input drop must keep the gif operation',
+    );
+    assert.equal(match.row.slug, 'mp4-to-gif');
+  });
+
+  it('mov dropped on /convert/mp4-to-gif is same-category (gif kept)', () => {
+    // The case-2 anchor from STRATEGY (case 3 = cross-category, case 2 =
+    // same-category). A mov on a gif page swaps the row but stays on `gif`
+    // — the operation does NOT flip. Verifies the cross-category logic
+    // doesn't over-trigger on legitimate same-category swaps.
+    const match = adaptiveRowForFile({ name: 'iphone.mov' }, 'gif', 'gif');
+    assert.ok(match);
+    assert.equal(
+      match.row.operation,
+      'gif',
+      'mov-to-gif row preserves the gif operation',
+    );
+    assert.equal(match.row.slug, 'mov-to-gif');
   });
 });


### PR DESCRIPTION
Closes #107

## Summary

- Derives `effectiveOperation` from `detectedRow?.operation` so cross-category drops (e.g. `.png` on `/convert/mp4-to-gif` → `image-convert`) flip the panel's operation in place.
- The URL-state whitelist, the SavedPresetsBar, and the Advanced disclosure now all read from `effectiveOperation` — gif-only params are silently dropped on the swap, and saved presets / Advanced panel switch surface to match the *detected* operation, not the slug's.
- `resolveArgsForFile` re-parses URL state through the new operation's whitelist before merging into `extraArgs`, so the in-flight POST doesn't ship stale params on a swapped operation.
- Page shell (h1, FAQ, "How it works", related siblings) stays untouched — those live in `<ToolPage />`. URL update via `history.replaceState` (existing SEAN-105 machinery), preserving the in-flight File object.
- Builds on top of #110 (SEAN-106) and #111 (SEAN-108) which both touched the same panel; rebased cleanly and added 7 tests for the new operation-switch behaviour (33 total passing).

## Test plan

- [x] `yarn test:converter-panel` — 33/33 passing including 7 new SEAN-107 tests.
- [x] `npx tsc --noEmit` clean for `apps/ffmpeg-converter/web`.
- [x] Biome clean for the two touched files.
- [ ] Manual: drop `.png` on `/convert/mp4-to-gif`. Expect URL → `/convert/image-to-webp`, panel converts PNG → WebP, chip row reorganises to PNG outputs (webp active), Advanced disclosure hidden, page h1 still reads "MP4 to GIF" (unchanged shell).
- [ ] Manual: drop `.mov` on `/convert/mp4-to-gif`. Expect same-category swap (operation stays `gif`); regression check for the SEAN-105/SEAN-106 path.