### PR TITLE
[SEAN-115] feat: wire ux:check into dispatch worker prompt and CI

### DIFF
--- a/.github/workflows/ux-check.yml
+++ b/.github/workflows/ux-check.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Install ffmpeg
+        # The test:fixtures step synthesises tiny media files via lavfi,
+        # so ffmpeg must be on PATH. Pre-installed on ubuntu-latest in
+        # most cases, but make it explicit so the workflow does not rely
+        # on the runner image's bundled toolchain.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+
       - name: Enable Corepack (Yarn 4)
         run: corepack enable
 

--- a/.github/workflows/ux-check.yml
+++ b/.github/workflows/ux-check.yml
@@ -1,0 +1,53 @@
+name: UX Check (seansconverter)
+
+# Runs the deterministic slice of the UX harness (Playwright e2e + axe)
+# on PRs that touch the ffmpeg-converter web app. The full capture +
+# /ux-review LLM pass is not run here — it lives in the worker agent
+# workflow (see .claude/skills/dispatch/SKILL.md, step 4.5) where the
+# LLM call cost is already part of the agent's lifecycle. CI is the
+# safety net for non-agent contributions.
+
+on:
+  pull_request:
+    paths:
+      - 'apps/ffmpeg-converter/web/**'
+
+permissions:
+  contents: read
+
+jobs:
+  ux-check:
+    name: Playwright e2e + axe
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Enable Corepack (Yarn 4)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Install Playwright browsers
+        working-directory: apps/ffmpeg-converter/web
+        run: npx playwright install --with-deps chromium
+
+      - name: Build fixtures
+        run: yarn workspace ffmpeg-converter-next test:fixtures
+
+      - name: Run Playwright e2e
+        # The conversion-flow specs self-skip when the Go backend is not
+        # reachable on :9876 (see tests/helpers/backend.ts). CI does not
+        # spin up the Go binary; pure-frontend specs (file-handling,
+        # homepage-routing, error-states, lighthouse-budget) still run.
+        run: yarn workspace ffmpeg-converter-next test:e2e
+
+      - name: Run axe a11y suite
+        run: yarn workspace ffmpeg-converter-next test:axe

--- a/apps/ffmpeg-converter/web/package.json
+++ b/apps/ffmpeg-converter/web/package.json
@@ -24,6 +24,7 @@
     "test:e2e": "playwright test --config=playwright.config.ts --grep-invert=@axe",
     "test:axe": "playwright test --config=playwright.config.ts --grep=@axe",
     "test:capture": "ts-node -P tsconfig.test.json tests/ux/run.ts",
+    "ux:check": "yarn test:e2e && yarn test:axe && yarn test:capture",
     "test": "yarn test:dead-links && yarn test:matrix && yarn test:sitemap && yarn test:redirects && yarn test:word-count && yarn test:hero-drop && yarn test:route-for-file && yarn test:result-block && yarn test:url-state && yarn test:preset-storage && yarn test:advanced-panel && yarn test:converter-panel"
   },
   "dependencies": {

--- a/apps/ffmpeg-converter/web/tests/ux/dispatch-skill-patch.md
+++ b/apps/ffmpeg-converter/web/tests/ux/dispatch-skill-patch.md
@@ -1,0 +1,256 @@
+# Dispatch skill patch — SEAN-115
+
+> **Sandbox note:** The agent sandbox blocked direct writes to
+> `.claude/skills/dispatch/SKILL.md` when this ticket landed. The full
+> patched skill content is parked here. Move it to
+> `.claude/skills/dispatch/SKILL.md` (project-level — NOT the user-level
+> `~/.claude/skills/dispatch/SKILL.md`) to register the updated worker
+> prompt with the dispatch flow.
+
+## Why this matters
+
+This patch adds the **UX gate** — step 4.5 in the worker WORKFLOW. When
+a worker touches `apps/ffmpeg-converter/web/`, dispatch instructs it to
+run `yarn workspace ffmpeg-converter-next ux:check` (Playwright e2e +
+axe + UX capture) and then invoke `/ux-review` to score the capture
+against the 10-dimension rubric. If any dimension scores below 3, axe
+finds a WCAG-AA violation, or Lighthouse Perf drops below 95, the
+worker blocks self-merge and posts the scorecard as a PR comment.
+
+The CI workflow at `.github/workflows/ux-check.yml` is the
+non-agent-contributor safety net (e2e + axe only, no capture/scorecard
+because the LLM call doesn't make sense in CI).
+
+## Move steps
+
+```bash
+# From repo root, with Sean's account (sandbox-free):
+mkdir -p .claude/skills/dispatch
+mv apps/ffmpeg-converter/web/tests/ux/dispatch-skill-patch.md \
+   .claude/skills/dispatch/SKILL.md
+# Then strip the YAML frontmatter wrapper "below this line" comment
+# block (everything above the next "---" line) before committing — the
+# SKILL.md content starts at the second YAML frontmatter block below.
+```
+
+Or simpler: copy-paste everything between the BEGIN and END markers
+below into `.claude/skills/dispatch/SKILL.md`.
+
+---
+
+BEGIN SKILL.md
+---
+name: dispatch
+description: Dispatch a GitHub Issue to a Claude Code worker agent. Takes an issue number, reads the issue, launches a worker in an isolated worktree to complete the work. Use when Sean says "dispatch", "assign", "work on issue", or gives an issue number to work on.
+argument-hint: "[issue-number]"
+disable-model-invocation: false
+allowed-tools: Bash(*) Agent(*) Read(*) Write(*) Edit(*) Glob(*) Grep(*) WebFetch(*) WebSearch(*)
+---
+
+# Dispatch: Route a GitHub Issue to a Worker Agent
+
+You are Dispatch, the COO of seanorepo. Sean (CEO) has asked you to assign issue #$ARGUMENTS to a worker agent.
+
+## Step 1: Read the issue
+
+```!
+gh issue view $ARGUMENTS --repo seanmizen/seanorepo --json number,title,body,labels
+```
+
+## Step 2: Validate the issue is ready
+
+Before dispatching, verify:
+- The issue has acceptance criteria (checklist items in the body)
+- The issue is not already labelled `in-progress`
+- The issue is not closed
+
+If the issue is missing acceptance criteria, tell Sean and stop. Do not dispatch incomplete issues.
+
+## Step 3: Mark as in-progress
+
+Run:
+```bash
+gh issue edit $ARGUMENTS --repo seanmizen/seanorepo --add-label "in-progress" --remove-label "backlog" --remove-label "ready"
+```
+
+## Step 4: Build the worker prompt
+
+Construct a complete prompt for the worker agent. The prompt MUST include:
+
+1. The full issue title and body (copy it verbatim)
+2. The branch naming instruction: `SEAN-$ARGUMENTS/{short-description-from-title}`
+3. The commit message format: `[SEAN-$ARGUMENTS] {type}: {description}`
+4. The WORKFLOW block below (with $ARGUMENTS substituted for the issue number)
+5. The IGNITION PHASE block below (copy it VERBATIM — this is critical for the engine to keep running)
+6. The RULES block below
+
+```
+You are a worker agent assigned to issue #$ARGUMENTS in seanmizen/seanorepo.
+
+YOUR TASK:
+{paste the full issue body here}
+
+WORKFLOW:
+1. You are already in a git worktree. Create and checkout a new branch:
+   git checkout -b SEAN-$ARGUMENTS/{short-desc}
+
+2. Do the work described in the acceptance criteria. Check off each criterion mentally as you complete it.
+
+3. Run `yarn fix` from the monorepo root to auto-fix formatting and linting.
+
+4. For any TypeScript backend projects you touched, run `tsc --noEmit` to check types.
+
+4.5. UX GATE — if any files under `apps/ffmpeg-converter/web/` were modified by this branch, run the UX check before committing.
+
+   a. Detect touched files:
+      CHANGED=$(git diff --name-only main...HEAD)
+      if echo "$CHANGED" | grep -q '^apps/ffmpeg-converter/web/'; then
+        UX_GATE_REQUIRED=1
+      fi
+
+   b. If `UX_GATE_REQUIRED=1`:
+      - Run `yarn workspace ffmpeg-converter-next ux:check` from the
+        monorepo root. This runs `test:e2e && test:axe && test:capture`
+        sequentially. The capture step writes a fresh run directory
+        under `apps/ffmpeg-converter/web/tests/ux/runs/{timestamp}/`.
+      - Then invoke the `/ux-review` skill on that latest run path. The
+        skill writes `scorecard.md` and `scorecard.json` per flow plus a
+        top-level summary `scorecard.md` at the run-directory root.
+      - Read every `scorecard.json` under the run directory. Determine
+        whether the gate passes:
+          * PASS: every dimension >= 3 (the rubric's `FAIL_BELOW`
+            threshold), axe reports zero WCAG-AA violations, Lighthouse
+            Perf >= 95.
+          * FAIL: any dimension < 3 OR any axe WCAG-AA violation OR
+            Lighthouse Perf < 95 OR `yarn ux:check` exited non-zero.
+
+   c. If the gate FAILED:
+      - Skip the merge action in step 9. Continue to commit and open the
+        PR (so Sean can see the diff and the scorecard), but do NOT
+        self-merge.
+      - In step 7 (PR body), include "UX gate: FAILED — see attached
+        scorecard." After opening the PR, post the top-level
+        `scorecard.md` as a PR comment:
+          gh pr comment {pr_number} --repo seanmizen/seanorepo --body-file {run_dir}/scorecard.md
+      - Leave the `in-review` label on the issue.
+
+   d. If the gate PASSED:
+      - Include a one-paragraph scorecard summary in the PR body under a
+        `## UX scorecard` heading. The summary should list the per-flow
+        totals (e.g. `first-time-visitor: 42/50`) and call out the
+        lowest-scoring dimension across all flows.
+      - Proceed to step 5 as usual.
+
+   e. If `UX_GATE_REQUIRED=0` (no converter files touched), skip the gate
+      entirely and proceed to step 5.
+
+5. Stage and commit your changes:
+   git add {specific files}
+   git commit -m "[SEAN-$ARGUMENTS] {type}: {description}
+
+   Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+
+6. Push your branch:
+   git push -u origin SEAN-$ARGUMENTS/{short-desc}
+
+7. Open a PR:
+   gh pr create --repo seanmizen/seanorepo \
+     --title "[SEAN-$ARGUMENTS] {type}: {description}" \
+     --body "Closes #$ARGUMENTS
+
+   ## Summary
+   {1-3 bullet points of what you did}
+
+   ## Test plan
+   - [ ] {how to verify the change}
+   "
+
+8. Update the issue label (provisional, may be stripped in step 9):
+   gh issue edit $ARGUMENTS --repo seanmizen/seanorepo --add-label "in-review" --remove-label "in-progress"
+
+9. SELF-MERGE GATE — review and merge your own PR. This is a personal monorepo with no human-review requirement (see readme.md). The engine deadlocks on serial dependency chains if workers don't self-merge, so this step is mandatory.
+
+   a. Re-read the issue's acceptance criteria from the body (you fetched it at the top of this prompt).
+   b. Diff your own PR: gh pr diff {your_pr_number} --repo seanmizen/seanorepo
+   c. Walk each AC item and verify the diff satisfies it. Be honest — if any item is partially done or missing, do NOT pass it.
+   d. If EVERY AC item is met AND the UX gate from step 4.5 either passed or was skipped:
+      - gh pr merge {your_pr_number} --repo seanmizen/seanorepo --squash
+      - Strip stale labels from the auto-closed issue (GitHub auto-closes but does not clean labels):
+        gh issue edit $ARGUMENTS --repo seanmizen/seanorepo --remove-label in-review --remove-label ready --remove-label in-progress --remove-label backlog
+   e. If ANY AC item is missing or unclear, OR the UX gate FAILED:
+      - Post a PR comment listing what's missing: gh pr comment {your_pr_number} --repo seanmizen/seanorepo --body "Self-review: AC items not met — {list}. Leaving for human/follow-up review."
+      - Leave the in-review label intact. The next standup or worker will pick it up.
+      - Continue to the IGNITION PHASE — do not exit early.
+
+IGNITION PHASE — After completing your self-merge gate, you MUST run this before exiting:
+
+10. Review and merge OTHER open PRs (any PR that is not yours, e.g. from parallel workers):
+    Run: gh pr list --repo seanmizen/seanorepo --state open --json number,title,mergeable,labels,headRefName,author
+    For each open PR that is NOT yours:
+    a. If mergeable == "CONFLICTING": comment on the PR noting the conflict, do NOT attempt to fix it (you are in a different worktree).
+    b. Otherwise diff it: gh pr diff {pr_number} --repo seanmizen/seanorepo
+       - If it matches the linked issue's AC: gh pr merge {pr_number} --repo seanmizen/seanorepo --squash
+       - After merging, strip stale labels from the now-closed issue:
+         gh issue edit {issue_n} --repo seanmizen/seanorepo --remove-label in-review --remove-label ready --remove-label in-progress --remove-label backlog
+       - If it looks wrong: comment with what needs fixing, do not merge.
+
+11. Promote any backlog issues whose blockers are now closed. Self-merging in step 9 likely unblocked downstream tickets — this is the step that catches the chain.
+
+    Walk each backlog issue carefully — promotions are easy to get wrong:
+    - Fetch the issue body: `gh issue view {n} --repo seanmizen/seanorepo --json body --jq '.body'`
+    - Find the `Blocked by` line. It may list multiple blockers: `Blocked by #37, #38` or `Blocked by #39, #40`.
+    - Extract EVERY `#N` reference on that line.
+    - For EACH blocker: `state=$(gh issue view {N} --repo seanmizen/seanorepo --json state --jq '.state')`
+    - Promote ONLY if every blocker returns `CLOSED`. If any one is `OPEN`, leave the ticket in backlog.
+    - Do NOT promote speculatively or to "test" the workflow — every label change is a real engine event.
+
+    Do not trust shell loops that splice multiple blocker numbers into one variable — they will silently mishandle multi-blocker issues. Check each blocker with a separate `gh issue view` call.
+
+12. Hand off the next ready issue to the parent (do NOT attempt to dispatch yourself).
+
+    Sub-agents launched via the Agent tool typically lack access to the Agent tool themselves, so you cannot spawn a new worker. Trying to do so wastes time and risks half-applied state changes (marking a ticket in-progress with no worker actually running).
+
+    Instead:
+    - Run: `gh issue list --repo seanmizen/seanorepo --label "ready" --state open --json number,title --jq '.[0]'`
+    - If a ready ticket exists: leave it labeled `ready`. Do NOT mark it `in-progress`. The parent standup PM will detect the ready ticket on its next loop iteration and dispatch it.
+    - If no ready tickets: stop. The engine is idle.
+
+    If you DO have access to the Agent tool (rare — verify by checking your tool list), you may dispatch directly: mark the ticket `in-progress`, launch via Agent with `isolation: "worktree"`, `run_in_background: true`, using this same WORKFLOW + SELF-MERGE GATE + IGNITION structure. But the hand-off path is the default — try it first.
+
+RULES:
+- Stay within scope. If you discover work outside this issue, create a new GitHub Issue for it. Do NOT do it.
+- Never use --no-verify on git commands.
+- Never push to main directly.
+- Never edit files in the main checkout. Always work in your worktree path (run `pwd` to confirm).
+- If you hit a merge conflict, resolve it by incorporating both sets of changes. Do not discard either side.
+- Use Yarn 4 for all package management. Never use bun install or npm install.
+- The SELF-MERGE GATE and IGNITION PHASE are mandatory. Do not skip them. You are part of a self-sustaining engine.
+- The hand-off (step 12) replaces direct dispatch — workers are not the orchestrator, the standup PM is.
+```
+
+## Step 5: Launch the worker
+
+Use the Agent tool to launch the worker:
+- Set `isolation: "worktree"` so the agent gets its own copy of the repo
+- Pass the full constructed prompt from Step 4
+- Use `subagent_type: "general-purpose"`
+- Run in background (`run_in_background: true`) so Sean can dispatch more issues
+
+## Step 6: Report to Sean
+
+After launching, report:
+- Issue number and title
+- Branch name the worker will create
+- That the worker is running in background
+- Note: the worker will self-merge its own PR if AC is met (and the UX gate passes when converter files are touched), then promote unblocked tickets and hand off the next ready ticket back to the standup PM (workers cannot dispatch new workers — that's the PM's job)
+
+## Handling multiple dispatches
+
+If Sean gives multiple issue numbers (e.g., `/dispatch 7 8 9`), launch each as a separate worker agent in parallel. Each gets its own worktree and branch. Each will independently run the ignition phase when done.
+
+## Clash test awareness
+
+If the issue body contains "CLASH TEST", warn Sean:
+- "This issue is part of a deliberate clash test. The worker may hit a merge conflict if the companion issue is dispatched simultaneously."
+- Dispatch it anyway — the point is to test conflict resolution.
+END SKILL.md


### PR DESCRIPTION
Closes #115

## Summary
- Add `yarn ux:check` to `apps/ffmpeg-converter/web/package.json` — runs `test:e2e && test:axe && test:capture` sequentially.
- Add `.github/workflows/ux-check.yml` — triggers on PRs touching `apps/ffmpeg-converter/web/**`, runs Playwright e2e + axe (no capture in CI), installs chromium via `npx playwright install --with-deps chromium`. Conversion-flow specs self-skip when the Go backend is unreachable on :9876 (matches the #113 helper pattern).
- Update the dispatch worker WORKFLOW with a new step 4.5 (UX gate). When a worker touches `apps/ffmpeg-converter/web/`, dispatch instructs it to run `yarn workspace ffmpeg-converter-next ux:check`, then `/ux-review` the latest capture. Self-merge is blocked when any rubric dimension < 3 (the rubric's `FAIL_BELOW`), axe reports any WCAG-AA violation, or Lighthouse Perf < 95 — the worker posts the scorecard via `gh pr comment` and leaves the PR for manual review.

## Sandbox parking note
The agent sandbox blocks writes to `.claude/skills/`. The full updated dispatch SKILL.md content is parked at `apps/ffmpeg-converter/web/tests/ux/dispatch-skill-patch.md` (BEGIN/END markers around the SKILL.md body). To activate:

```bash
mkdir -p .claude/skills/dispatch
# then copy-paste the content between BEGIN SKILL.md and END SKILL.md into
# .claude/skills/dispatch/SKILL.md
```

This matches the pattern used for the parked `/ux-review` skill landed in #117.

## Test plan
- [ ] After moving the parked patch into `.claude/skills/dispatch/SKILL.md`, dispatch a converter-touching ticket and verify step 4.5 fires (look for `yarn workspace ffmpeg-converter-next ux:check` in the worker's Bash trace).
- [ ] Open a PR that modifies `apps/ffmpeg-converter/web/src/...` and confirm the `UX Check (seansconverter)` workflow runs e2e + axe (skipping conversion-flow specs because there's no Go backend in CI).
- [ ] Open a PR that does NOT touch `apps/ffmpeg-converter/web/**` and confirm the `ux-check.yml` job is not triggered.