### PR TITLE
[SEAN-122] chore: document converter feature freeze lesson

### DIFF
--- a/.claude/dispatch-playbook.md
+++ b/.claude/dispatch-playbook.md
@@ -17,6 +17,18 @@ is needed for three things:
 2. **Intake** -- turning Sean's raw ideas into well-formed tickets.
 3. **Exception handling** -- unsticking workers, enforcing WIP limits, running retros.
 
+### The "where on earth is GIF?" lesson (issue #122)
+
+Between #75 and #108, the converter shipped 19 feature tickets in two days. Every PR
+self-merged because every acceptance criterion was met. Then Sean opened the running site
+and asked "where on earth is GIF?" -- a class of mental-model drift that no individual
+ticket could have caught, because each ticket was internally consistent. **Every PR
+self-merging is not the same as every PR being right; eyes on the running product is the
+gate.** The AI UX Verification harness (#113 / #114 / #115) exists for exactly this reason
+-- treat its `ux:check` step as the real done-condition for any feature whose effect is
+visible to a user, and prefer pausing a feature stream over compounding drift when that
+gate is degraded or absent.
+
 ---
 
 ## 1. Creating Tickets from Raw Ideas


### PR DESCRIPTION
Closes #122

## Summary

- Adds the "where on earth is GIF?" lesson to `.claude/dispatch-playbook.md` Mental Model section, capturing the rationale: every PR self-merging is not the same as every PR being right; eyes on the running product is the gate.
- **Skipped** AC #1 (the dispatch SKILL.md guard step) per the PM's recommended interpretation in the issue: blockers #113/#114/#115 are all CLOSED, so the freeze period is over and the guard would be a no-op the moment it was written. AC #3 explicitly allows the guard to "self-remove" once #115 closes — same outcome here, the dead branch was never written. Sean's anti-hedging rule applies (no "until we scale" / "ready to swap" code that's already dead).
- AC #2, #3, #5 are satisfied by extension: exemptions are moot, guard already self-removed, no tooling change beyond the doc note.

## Test plan

- [ ] `cat .claude/dispatch-playbook.md | sed -n '20,32p'` shows the new "where on earth is GIF?" subsection under Mental Model.
- [ ] No other files modified (this is a doc-only change).
- [ ] If Sean disagrees with the skip-AC-#1 interpretation, the guard can be added in a follow-up ticket — both readings were defensible per the PM note.